### PR TITLE
feat(login): add third-party web login

### DIFF
--- a/lib/http/api.dart
+++ b/lib/http/api.dart
@@ -47,6 +47,10 @@ abstract final class Api {
   // https://api.bilibili.com/x/web-interface/archive/like
   // static const String likeVideo = '/x/web-interface/archive/like';
 
+  /// web端点赞接口（无access_key时fallback）
+  static const String likeVideoWeb = '/x/web-interface/archive/like';
+
+
   // 改用app端点赞接口
   static const String likeVideo = '${HttpString.appBaseUrl}/x/v2/view/like';
   //判断视频是否被点赞（双端）Get
@@ -74,6 +78,10 @@ abstract final class Api {
   /// select_like	num	是否附加点赞	非必要	0：不点赞 1：同时点赞 默认为0
   // csrf	str	CSRF Token（位于cookie）	必要
   // https://api.bilibili.com/x/web-interface/coin/add
+
+  /// web端投币接口（无access_key时fallback）
+  static const String coinVideoWeb = '/x/web-interface/coin/add';
+
   // static const String coinVideo = '/x/web-interface/coin/add';
 
   // 改用app端投币接口

--- a/lib/http/api.dart
+++ b/lib/http/api.dart
@@ -620,6 +620,8 @@ abstract final class Api {
   static const String oauth2AccessToken =
       '${HttpString.passBaseUrl}/x/passport-login/oauth2/access_token';
 
+  static const String memberWebAccount = '/x/member/web/account';
+
   /// 密码加密密钥
   /// disable_rcmd
   /// local_id

--- a/lib/http/browser_ua.dart
+++ b/lib/http/browser_ua.dart
@@ -6,6 +6,9 @@ abstract final class BrowserUa {
   static const pc =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15';
 
+  static const pcChrome =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
   static const mob =
       'Mozilla/5.0 (Linux; Android 10; SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Mobile Safari/537.36';
 }

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -378,16 +378,30 @@ abstract final class VideoHttp {
     required int multiply,
     int selectLike = 0,
   }) async {
+    final hasAccessKey = !Accounts.main.accessKey.isNullOrEmpty;
+    late final Options opts;
+    if (hasAccessKey) {
+      opts = Options(contentType: Headers.formUrlEncodedContentType);
+    } else {
+      opts = Options(
+        contentType: Headers.formUrlEncodedContentType,
+        headers: {
+          'origin': 'https://www.bilibili.com',
+          'referer': 'https://www.bilibili.com/video/$bvid',
+          'user-agent': BrowserUa.pc,
+        },
+      );
+    }
     final res = await Request().post(
-      Api.coinVideo,
+      hasAccessKey ? Api.coinVideo : Api.coinVideoWeb,
       data: {
         'aid': IdUtils.bv2av(bvid).toString(),
         // 'bvid': bvid,
         'multiply': multiply.toString(),
         'select_like': selectLike.toString(),
-        // 'csrf': Accounts.main.csrf,
+        if (!hasAccessKey) 'csrf': Accounts.main.csrf,
       },
-      options: Options(contentType: Headers.formUrlEncodedContentType),
+      options: opts,
     );
     if (res.data['code'] == 0) {
       return const Success(null);
@@ -458,13 +472,33 @@ abstract final class VideoHttp {
     required String bvid,
     required bool type,
   }) async {
+    final hasAccessKey = !Accounts.main.accessKey.isNullOrEmpty;
+    late final Options opts;
+    if (hasAccessKey) {
+      opts = Options(contentType: Headers.formUrlEncodedContentType);
+    } else {
+      opts = Options(
+        contentType: Headers.formUrlEncodedContentType,
+        headers: {
+          'origin': 'https://www.bilibili.com',
+          'referer': 'https://www.bilibili.com/video/$bvid',
+          'user-agent': BrowserUa.pc,
+        },
+      );
+    }
     final res = await Request().post(
-      Api.likeVideo,
-      data: {'aid': IdUtils.bv2av(bvid).toString(), 'like': type ? '0' : '1'},
-      options: Options(contentType: Headers.formUrlEncodedContentType),
+      hasAccessKey ? Api.likeVideo : Api.likeVideoWeb,
+      data: hasAccessKey
+          ? {'aid': IdUtils.bv2av(bvid).toString(), 'like': type ? '0' : '1'}
+          : {
+              'aid': IdUtils.bv2av(bvid).toString(),
+              'like': type ? '1' : '2',
+              'csrf': Accounts.main.csrf,
+            },
+      options: opts,
     );
     if (res.data['code'] == 0) {
-      return Success(res.data['data']['toast']);
+      return Success(res.data['data']?['toast'] as String? ?? '点赞成功');
     } else {
       return Error(res.data['message']);
     }

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -379,19 +379,16 @@ abstract final class VideoHttp {
     int selectLike = 0,
   }) async {
     final hasAccessKey = !Accounts.main.accessKey.isNullOrEmpty;
-    late final Options opts;
-    if (hasAccessKey) {
-      opts = Options(contentType: Headers.formUrlEncodedContentType);
-    } else {
-      opts = Options(
-        contentType: Headers.formUrlEncodedContentType,
-        headers: {
-          'origin': 'https://www.bilibili.com',
-          'referer': 'https://www.bilibili.com/video/$bvid',
-          'user-agent': BrowserUa.pc,
-        },
-      );
-    }
+    final options = Options(
+      contentType: Headers.formUrlEncodedContentType,
+      headers: hasAccessKey
+          ? null
+          : {
+              'origin': 'https://www.bilibili.com',
+              'referer': 'https://www.bilibili.com/video/$bvid',
+              'user-agent': BrowserUa.pc,
+            },
+    );
     final res = await Request().post(
       hasAccessKey ? Api.coinVideo : Api.coinVideoWeb,
       data: {
@@ -401,7 +398,7 @@ abstract final class VideoHttp {
         'select_like': selectLike.toString(),
         if (!hasAccessKey) 'csrf': Accounts.main.csrf,
       },
-      options: opts,
+      options: options,
     );
     if (res.data['code'] == 0) {
       return const Success(null);
@@ -473,19 +470,16 @@ abstract final class VideoHttp {
     required bool type,
   }) async {
     final hasAccessKey = !Accounts.main.accessKey.isNullOrEmpty;
-    late final Options opts;
-    if (hasAccessKey) {
-      opts = Options(contentType: Headers.formUrlEncodedContentType);
-    } else {
-      opts = Options(
-        contentType: Headers.formUrlEncodedContentType,
-        headers: {
-          'origin': 'https://www.bilibili.com',
-          'referer': 'https://www.bilibili.com/video/$bvid',
-          'user-agent': BrowserUa.pc,
-        },
-      );
-    }
+    final options = Options(
+      contentType: Headers.formUrlEncodedContentType,
+      headers: hasAccessKey
+          ? null
+          : {
+              'origin': 'https://www.bilibili.com',
+              'referer': 'https://www.bilibili.com/video/$bvid',
+              'user-agent': BrowserUa.pc,
+            },
+    );
     final res = await Request().post(
       hasAccessKey ? Api.likeVideo : Api.likeVideoWeb,
       data: hasAccessKey
@@ -495,7 +489,7 @@ abstract final class VideoHttp {
               'like': type ? '1' : '2',
               'csrf': Accounts.main.csrf,
             },
-      options: opts,
+      options: options,
     );
     if (res.data['code'] == 0) {
       return Success(res.data['data']?['toast'] as String? ?? '点赞成功');

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -7,6 +7,7 @@ import 'package:PiliPlus/common/widgets/radio_widget.dart';
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/login.dart';
+import 'package:PiliPlus/main.dart' show webViewEnvironment;
 import 'package:PiliPlus/models/common/account_type.dart';
 import 'package:PiliPlus/models/login/model.dart';
 import 'package:PiliPlus/pages/login/geetest/geetest_webview_dialog.dart';
@@ -17,6 +18,7 @@ import 'package:PiliPlus/utils/theme_utils.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as web;
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 
@@ -47,6 +49,15 @@ class LoginPageController extends GetxController
   Timer? smsSendCooldownTimer;
 
   bool _isReq = false;
+  bool _isImportingWebLogin = false;
+
+  static const Set<String> _requiredWebLoginCookies = {
+    'SESSDATA',
+    'DedeUserID',
+    'bili_jct',
+    'DedeUserID__ckMd5',
+    'sid',
+  };
 
   @override
   void onInit() {
@@ -157,43 +168,139 @@ class LoginPageController extends GetxController
       SmartDialog.showToast('cookie不能为空');
       return;
     }
+    final cookieMap = _cookieMapFromText(cookieTextController.text);
+    final missing = _requiredWebLoginCookies.difference(cookieMap.keys.toSet());
+    if (missing.isNotEmpty) {
+      SmartDialog.showToast('缺少必要cookie: ${missing.join(", ")}');
+      return;
+    }
+    final saved = await _saveCookieAccount(
+      cookieMap,
+      invalidToast: '哔哩哔哩登录已失效，请重新登录',
+      errorToast: '获取哔哩哔哩用户信息失败，可前往账号管理重试',
+    );
+    if (saved) {
+      await _completeLogin();
+      Get.back();
+    }
+  }
+
+  static Map<String, String> _cookieMapFromText(String cookieText) {
+    final map = <String, String>{};
+    for (final item in validateCookie(cookieText).split(';')) {
+      final trimmed = item.trim();
+      if (trimmed.isEmpty) {
+        continue;
+      }
+      final cookie = Cookie.fromSetCookieValue(trimmed);
+      if (cookie.value.isNotEmpty) {
+        map[cookie.name] = cookie.value;
+      }
+    }
+    return map;
+  }
+
+  static String _cookieHeader(Map<String, String> cookieMap) {
+    return cookieMap.entries
+        .map((entry) => '${entry.key}=${entry.value}')
+        .join('; ');
+  }
+
+  Future<bool> _saveCookieAccount(
+    Map<String, String> cookieMap, {
+    required String invalidToast,
+    required String errorToast,
+  }) async {
+    if (cookieMap.isEmpty) {
+      SmartDialog.showToast(invalidToast);
+      return false;
+    }
     try {
       final result = await Request().get(
         "/x/member/web/account",
         options: Options(
-          headers: {
-            "cookie": validateCookie(cookieTextController.text),
-          },
+          headers: {"cookie": _cookieHeader(cookieMap)},
           extra: {'account': AnonymousAccount()},
         ),
       );
       if (result.data['code'] == 0) {
-        try {
-          await LoginAccount(
-            BiliCookieJar.fromJson(
-              Map.fromEntries(
-                cookieTextController.text.split(';').map((item) {
-                  final list = item.split('=');
-                  return MapEntry(list.first, list.skip(1).join());
-                }),
-              ),
-            ),
-            null,
-            null,
-          ).onChange();
-          if (!Accounts.main.isLogin) await switchAccountDialog(Get.context!);
-          SmartDialog.showToast('登录成功');
-          Get.back();
-        } catch (e) {
-          SmartDialog.showToast("登录失败: $e");
-        }
-      } else {
-        SmartDialog.showToast("哔哩哔哩登录已失效，请重新登录");
+        await _saveAccount(
+          LoginAccount(BiliCookieJar.fromJson(cookieMap), null, null),
+        );
+        return true;
       }
+      SmartDialog.showToast(invalidToast);
     } catch (e) {
-      SmartDialog.showToast("获取哔哩哔哩用户信息失败，可前往账号管理重试");
+      SmartDialog.showToast('$errorToast: $e');
+    }
+    return false;
+  }
+
+  Future<void> importWebLoginCookies({bool showResultToast = false}) async {
+    if (!Platform.isAndroid || _isImportingWebLogin) {
+      return;
+    }
+    _isImportingWebLogin = true;
+    try {
+      final cookieManager = web.CookieManager.instance(
+        webViewEnvironment: webViewEnvironment,
+      );
+      final cookiesByName = <String, web.Cookie>{};
+      for (final url in const [
+        'https://www.bilibili.com',
+        'https://passport.bilibili.com',
+        'https://api.bilibili.com',
+      ]) {
+        final cookies = await cookieManager.getCookies(url: web.WebUri(url));
+        for (final cookie in cookies) {
+          if (_webCookieValue(cookie).isNotEmpty) {
+            cookiesByName[cookie.name] = cookie;
+          }
+        }
+      }
+      await setCookieAccountFromWebCookies(
+        cookiesByName.values.toList(),
+        showResultToast: showResultToast,
+      );
+    } catch (e) {
+      if (showResultToast) {
+        SmartDialog.showToast('检测网页登录状态失败: $e');
+      }
+    } finally {
+      _isImportingWebLogin = false;
     }
   }
+
+  Future<void> setCookieAccountFromWebCookies(
+    List<web.Cookie> cookies, {
+    bool showResultToast = true,
+  }) async {
+    final cookieMap = {
+      for (final cookie in cookies)
+        if (_webCookieValue(cookie).isNotEmpty)
+          cookie.name: _webCookieValue(cookie),
+    };
+    final missing = _requiredWebLoginCookies.difference(cookieMap.keys.toSet());
+    if (missing.isNotEmpty) {
+      if (showResultToast) {
+        SmartDialog.showToast('网页登录态未生效，请完成扫码授权后重试');
+      }
+      return;
+    }
+
+    final saved = await _saveCookieAccount(
+      cookieMap,
+      invalidToast: '网页登录态未生效，请完成扫码授权后重试',
+      errorToast: '登录失败',
+    );
+    if (saved) {
+      await _completeLogin();
+      Get.back();
+    }
+  }
+
+  static String _webCookieValue(web.Cookie cookie) =>
+      cookie.value?.toString() ?? '';
 
   // app端密码登录
   Future<void> loginByPassword() async {
@@ -624,17 +731,25 @@ class LoginPageController extends GetxController
       tokenInfo['access_token'],
       tokenInfo['refresh_token'],
     );
-    await Future.wait([account.onChange(), AnonymousAccount().delete()]);
-    for (int i = 0; i < AccountType.values.length; i++) {
-      if (Accounts.accountMode[i].mid == account.mid) {
-        Accounts.accountMode[i] = account;
-      }
-    }
+    await _saveAccount(account);
+    await _completeLogin();
+  }
+
+  Future<void> _completeLogin() async {
     if (Accounts.main.isLogin) {
       SmartDialog.showToast('登录成功');
     } else {
       SmartDialog.showToast('登录成功, 请先设置账号模式');
       await switchAccountDialog(Get.context!);
+    }
+  }
+
+  Future<void> _saveAccount(LoginAccount account) async {
+    await Future.wait([account.onChange(), AnonymousAccount().delete()]);
+    for (int i = 0; i < AccountType.values.length; i++) {
+      if (Accounts.accountMode[i].mid == account.mid) {
+        Accounts.accountMode[i] = account;
+      }
     }
   }
 

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -236,9 +236,9 @@ class LoginPageController extends GetxController
     return false;
   }
 
-  Future<void> importWebLoginCookies({bool showResultToast = false}) async {
+  Future<bool> importWebLoginCookies({bool showResultToast = false}) async {
     if (!Platform.isAndroid || _isImportingWebLogin) {
-      return;
+      return false;
     }
     _isImportingWebLogin = true;
     try {
@@ -258,7 +258,7 @@ class LoginPageController extends GetxController
           }
         }
       }
-      await setCookieAccountFromWebCookies(
+      return await setCookieAccountFromWebCookies(
         cookiesByName.values.toList(),
         showResultToast: showResultToast,
       );
@@ -266,12 +266,13 @@ class LoginPageController extends GetxController
       if (showResultToast) {
         SmartDialog.showToast('检测网页登录状态失败: $e');
       }
+      return false;
     } finally {
       _isImportingWebLogin = false;
     }
   }
 
-  Future<void> setCookieAccountFromWebCookies(
+  Future<bool> setCookieAccountFromWebCookies(
     List<web.Cookie> cookies, {
     bool showResultToast = true,
   }) async {
@@ -285,7 +286,7 @@ class LoginPageController extends GetxController
       if (showResultToast) {
         SmartDialog.showToast('网页登录态未生效，请完成扫码授权后重试');
       }
-      return;
+      return false;
     }
 
     final saved = await _saveCookieAccount(
@@ -295,8 +296,9 @@ class LoginPageController extends GetxController
     );
     if (saved) {
       await _completeLogin();
-      Get.back();
+      return true;
     }
+    return false;
   }
 
   static String _webCookieValue(web.Cookie cookie) =>

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:PiliPlus/common/dial_prefix.dart';
 import 'package:PiliPlus/common/widgets/button/icon_button.dart';
 import 'package:PiliPlus/common/widgets/radio_widget.dart';
+import 'package:PiliPlus/http/api.dart';
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/login.dart';
@@ -55,8 +56,6 @@ class LoginPageController extends GetxController
     'SESSDATA',
     'DedeUserID',
     'bili_jct',
-    'DedeUserID__ckMd5',
-    'sid',
   };
 
   @override
@@ -169,16 +168,15 @@ class LoginPageController extends GetxController
       return;
     }
     final cookieMap = _cookieMapFromText(cookieTextController.text);
-    final missing = _requiredWebLoginCookies.difference(cookieMap.keys.toSet());
-    if (missing.isNotEmpty) {
-      SmartDialog.showToast('缺少必要cookie: ${missing.join(", ")}');
-      return;
-    }
-    final saved = await _saveCookieAccount(
+    final verified = await _verifyCookieAccount(
       cookieMap,
       invalidToast: '哔哩哔哩登录已失效，请重新登录',
-      errorToast: '获取哔哩哔哩用户信息失败，可前往账号管理重试',
+      requestErrorToast: '获取哔哩哔哩用户信息失败，可前往账号管理重试',
     );
+    if (!verified) {
+      return;
+    }
+    final saved = await _persistCookieAccount(cookieMap);
     if (saved) {
       await _completeLogin();
       Get.back();
@@ -206,10 +204,11 @@ class LoginPageController extends GetxController
         .join('; ');
   }
 
-  Future<bool> _saveCookieAccount(
+  Future<bool> _verifyCookieAccount(
     Map<String, String> cookieMap, {
     required String invalidToast,
-    required String errorToast,
+    required String requestErrorToast,
+    bool appendRequestError = false,
   }) async {
     if (cookieMap.isEmpty) {
       SmartDialog.showToast(invalidToast);
@@ -217,26 +216,40 @@ class LoginPageController extends GetxController
     }
     try {
       final result = await Request().get(
-        "/x/member/web/account",
+        Api.memberWebAccount,
         options: Options(
           headers: {"cookie": _cookieHeader(cookieMap)},
           extra: {'account': AnonymousAccount()},
         ),
       );
       if (result.data['code'] == 0) {
-        await _saveAccount(
-          LoginAccount(BiliCookieJar.fromJson(cookieMap), null, null),
-        );
         return true;
       }
       SmartDialog.showToast(invalidToast);
     } catch (e) {
-      SmartDialog.showToast('$errorToast: $e');
+      SmartDialog.showToast(
+        appendRequestError ? '$requestErrorToast: $e' : requestErrorToast,
+      );
     }
     return false;
   }
 
-  Future<bool> importWebLoginCookies({bool showResultToast = false}) async {
+  Future<bool> _persistCookieAccount(
+    Map<String, String> cookieMap, {
+    String saveErrorToast = '登录失败',
+  }) async {
+    try {
+      await _saveAccount(
+        LoginAccount(BiliCookieJar.fromJson(cookieMap), null, null),
+      );
+      return true;
+    } catch (e) {
+      SmartDialog.showToast('$saveErrorToast: $e');
+      return false;
+    }
+  }
+
+  Future<bool> importWebLoginAccount({bool showResultToast = false}) async {
     if (!Platform.isAndroid || _isImportingWebLogin) {
       return false;
     }
@@ -258,7 +271,7 @@ class LoginPageController extends GetxController
           }
         }
       }
-      return await setCookieAccountFromWebCookies(
+      return await _importWebLoginAccountFromCookies(
         cookiesByName.values.toList(),
         showResultToast: showResultToast,
       );
@@ -272,9 +285,9 @@ class LoginPageController extends GetxController
     }
   }
 
-  Future<bool> setCookieAccountFromWebCookies(
+  Future<bool> _importWebLoginAccountFromCookies(
     List<web.Cookie> cookies, {
-    bool showResultToast = true,
+    required bool showResultToast,
   }) async {
     final cookieMap = {
       for (final cookie in cookies)
@@ -289,11 +302,16 @@ class LoginPageController extends GetxController
       return false;
     }
 
-    final saved = await _saveCookieAccount(
+    final verified = await _verifyCookieAccount(
       cookieMap,
       invalidToast: '网页登录态未生效，请完成扫码授权后重试',
-      errorToast: '登录失败',
+      requestErrorToast: '登录失败',
+      appendRequestError: true,
     );
+    if (!verified) {
+      return false;
+    }
+    final saved = await _persistCookieAccount(cookieMap);
     if (saved) {
       await _completeLogin();
       return true;

--- a/lib/pages/login/third_party_login_view.dart
+++ b/lib/pages/login/third_party_login_view.dart
@@ -1,0 +1,250 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:PiliPlus/http/browser_ua.dart';
+import 'package:PiliPlus/main.dart' show webViewEnvironment;
+import 'package:PiliPlus/pages/login/controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class ThirdPartyLoginView extends StatefulWidget {
+  const ThirdPartyLoginView({
+    super.key,
+    required this.controller,
+    required this.padding,
+  });
+
+  final LoginPageController controller;
+  final EdgeInsets padding;
+
+  @override
+  State<ThirdPartyLoginView> createState() => _ThirdPartyLoginViewState();
+}
+
+class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
+    with WidgetsBindingObserver {
+  static const _desktopUserAgent = BrowserUa.pcChrome;
+
+  static final WebUri _loginUri = WebUri(
+    'https://passport.bilibili.com/h5-app/passport/login',
+  );
+
+  static final UnmodifiableListView<UserScript> _desktopUserScripts =
+      UnmodifiableListView([
+        UserScript(
+          source: _desktopFingerprintScript,
+          injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+          contentWorld: ContentWorld.PAGE,
+        ),
+      ]);
+
+  static const _desktopFingerprintScript =
+      '''
+(() => {
+  const define = (target, property, value) => {
+    try {
+      Object.defineProperty(target, property, {
+        get: () => value,
+        configurable: true,
+      });
+    } catch (_) {}
+  };
+
+  define(Navigator.prototype, 'userAgent', '$_desktopUserAgent');
+  define(Navigator.prototype, 'appVersion', '5.0 (Windows NT 10.0; Win64; x64)');
+  define(Navigator.prototype, 'platform', 'Win32');
+  define(Navigator.prototype, 'vendor', 'Google Inc.');
+  define(Navigator.prototype, 'maxTouchPoints', 0);
+  define(Navigator.prototype, 'webdriver', false);
+  define(Navigator.prototype, 'language', 'zh-CN');
+  define(Navigator.prototype, 'languages', ['zh-CN', 'zh']);
+  define(Navigator.prototype, 'userAgentData', {
+    brands: [
+      {brand: 'Chromium', version: '120'},
+      {brand: 'Google Chrome', version: '120'},
+      {brand: 'Not?A_Brand', version: '99'},
+    ],
+    mobile: false,
+    platform: 'Windows',
+    getHighEntropyValues: async (hints) => {
+      architecture: 'x86',
+      bitness: '64',
+      brands: [
+        {brand: 'Chromium', version: '120'},
+        {brand: 'Google Chrome', version: '120'},
+        {brand: 'Not?A_Brand', version: '99'},
+      ],
+      fullVersionList: [
+        {brand: 'Chromium', version: '120.0.0.0'},
+        {brand: 'Google Chrome', version: '120.0.0.0'},
+        {brand: 'Not?A_Brand', version: '99.0.0.0'},
+      ],
+      mobile: false,
+      model: '',
+      platform: 'Windows',
+      platformVersion: '10.0.0',
+      uaFullVersion: '120.0.0.0',
+    },
+    toJSON() {
+      return {
+        brands: this.brands,
+        mobile: false,
+        platform: 'Windows',
+      };
+    },
+  });
+
+  define(window, 'ontouchstart', undefined);
+})();
+''';
+
+  static const Set<String> _externalSchemes = {
+    'mqqapi',
+    'wtloginmqq',
+    'weixin',
+    'wechat',
+    'sinaweibo',
+  };
+
+  final RxDouble _progress = 0.0.obs;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _detectLoginStatus();
+    }
+  }
+
+  Future<void> _detectLoginStatus({bool showResultToast = false}) {
+    return widget.controller.importWebLoginCookies(
+      showResultToast: showResultToast,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isAndroid) {
+      return const Center(child: Text('第三方网页登录仅支持 Android APK'));
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: Stack(
+            children: [
+              InAppWebView(
+                webViewEnvironment: webViewEnvironment,
+                initialUserScripts: _desktopUserScripts,
+                initialSettings: InAppWebViewSettings(
+                  javaScriptEnabled: true,
+                  domStorageEnabled: true,
+                  databaseEnabled: true,
+                  thirdPartyCookiesEnabled: true,
+                  supportMultipleWindows: true,
+                  javaScriptCanOpenWindowsAutomatically: true,
+                  useShouldOverrideUrlLoading: true,
+                  forceDark: ForceDark.AUTO,
+                  algorithmicDarkeningAllowed: true,
+                  mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+                  userAgent: _desktopUserAgent,
+                  useWideViewPort: true,
+                  loadWithOverviewMode: true,
+                  supportZoom: true,
+                  builtInZoomControls: true,
+                  displayZoomControls: false,
+                  textZoom: 100,
+                ),
+                initialUrlRequest: URLRequest(url: _loginUri),
+                onProgressChanged: (_, progress) {
+                  _progress.value = progress / 100;
+                },
+                onLoadStop: (_, _) {
+                  _progress.value = 1;
+                  _detectLoginStatus();
+                },
+                onUpdateVisitedHistory: (_, _, _) {
+                  _detectLoginStatus();
+                },
+                onReceivedHttpAuthRequest: (_, _) async {
+                  await _detectLoginStatus();
+                  return null;
+                },
+                onCreateWindow: (controller, createWindowAction) async {
+                  final url = createWindowAction.request.url;
+                  if (url != null) {
+                    await controller.loadUrl(urlRequest: URLRequest(url: url));
+                  }
+                  return true;
+                },
+                shouldOverrideUrlLoading: (_, navigationAction) async {
+                  final uri = navigationAction.request.url;
+                  if (uri == null) {
+                    return NavigationActionPolicy.ALLOW;
+                  }
+                  if (_externalSchemes.contains(uri.scheme.toLowerCase())) {
+                    await _openExternalUri(context, uri);
+                    return NavigationActionPolicy.CANCEL;
+                  }
+                  return NavigationActionPolicy.ALLOW;
+                },
+              ),
+              Obx(
+                () => _progress.value < 1
+                    ? LinearProgressIndicator(value: _progress.value)
+                    : const SizedBox.shrink(),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: widget.padding.bottom),
+      ],
+    );
+  }
+
+  Future<void> _openExternalUri(BuildContext context, WebUri uri) async {
+    final target = uri.uriValue;
+    final open = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('打开外部应用'),
+        content: Text(uri.toString()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(
+              '取消',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('打开'),
+          ),
+        ],
+      ),
+    );
+    if (open != true) {
+      return;
+    }
+    if (!await launchUrl(
+      target,
+      mode: LaunchMode.externalNonBrowserApplication,
+    )) {
+      await launchUrl(target, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/lib/pages/login/third_party_login_view.dart
+++ b/lib/pages/login/third_party_login_view.dart
@@ -68,7 +68,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
     ],
     mobile: false,
     platform: 'Windows',
-    getHighEntropyValues: async (hints) => {
+    getHighEntropyValues: async (hints) => ({
       architecture: 'x86',
       bitness: '64',
       brands: [
@@ -86,7 +86,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
       platform: 'Windows',
       platformVersion: '10.0.0',
       uaFullVersion: '120.0.0.0',
-    },
+    }),
     toJSON() {
       return {
         brands: this.brands,
@@ -129,10 +129,14 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
     }
   }
 
-  Future<void> _detectLoginStatus({bool showResultToast = false}) {
-    return widget.controller.importWebLoginCookies(
+  Future<void> _detectLoginStatus({bool showResultToast = false}) async {
+    final isLoggedIn = await widget.controller.importWebLoginCookies(
       showResultToast: showResultToast,
     );
+    if (!mounted || !isLoggedIn) {
+      return;
+    }
+    Navigator.of(context).pop(true);
   }
 
   @override
@@ -179,10 +183,6 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
                 onUpdateVisitedHistory: (_, _, _) {
                   _detectLoginStatus();
                 },
-                onReceivedHttpAuthRequest: (_, _) async {
-                  await _detectLoginStatus();
-                  return null;
-                },
                 onCreateWindow: (controller, createWindowAction) async {
                   final url = createWindowAction.request.url;
                   if (url != null) {
@@ -196,7 +196,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
                     return NavigationActionPolicy.ALLOW;
                   }
                   if (_externalSchemes.contains(uri.scheme.toLowerCase())) {
-                    await _openExternalUri(context, uri);
+                    await _openExternalUri(uri);
                     return NavigationActionPolicy.CANCEL;
                   }
                   return NavigationActionPolicy.ALLOW;
@@ -210,15 +210,28 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
             ],
           ),
         ),
-        SizedBox(height: widget.padding.bottom),
+        Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, widget.padding.bottom),
+          child: SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: () => _detectLoginStatus(showResultToast: true),
+              icon: const Icon(Icons.verified_user_outlined),
+              label: const Text('检测登录'),
+            ),
+          ),
+        ),
       ],
     );
   }
 
-  Future<void> _openExternalUri(BuildContext context, WebUri uri) async {
+  Future<void> _openExternalUri(WebUri uri) async {
+    if (!mounted) {
+      return;
+    }
     final target = uri.uriValue;
     final open = await showDialog<bool>(
-      context: context,
+      context: this.context,
       builder: (context) => AlertDialog(
         title: const Text('打开外部应用'),
         content: Text(uri.toString()),
@@ -237,7 +250,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
         ],
       ),
     );
-    if (open != true) {
+    if (!mounted || open != true) {
       return;
     }
     if (!await launchUrl(

--- a/lib/pages/login/view.dart
+++ b/lib/pages/login/view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/dial_prefix.dart';
 import 'package:PiliPlus/common/widgets/flutter/popup_menu.dart';
@@ -6,6 +8,7 @@ import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/login/controller.dart';
+import 'package:PiliPlus/pages/login/third_party_login_view.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
 import 'package:PiliPlus/utils/extension/widget_ext.dart';
 import 'package:PiliPlus/utils/image_utils.dart';
@@ -207,7 +210,45 @@ class _LoginPageState extends State<LoginPage> {
           icon: const Icon(Icons.login),
           label: const Text('登录'),
         ),
+        if (Platform.isAndroid) ...[
+          const SizedBox(height: 8),
+          TextButton.icon(
+            onPressed: _openThirdPartyLogin,
+            icon: const Icon(Icons.language_outlined),
+            label: const Text('网页登录获取 Cookie'),
+          ),
+        ],
       ],
+    );
+  }
+
+  Future<void> _openThirdPartyLogin() {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => FractionallySizedBox(
+        heightFactor: 0.92,
+        child: Column(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.language_outlined),
+              title: const Text('网页登录'),
+              trailing: IconButton(
+                tooltip: '关闭',
+                icon: const Icon(Icons.close),
+                onPressed: Get.back,
+              ),
+            ),
+            Expanded(
+              child: ThirdPartyLoginView(
+                controller: _loginPageCtr,
+                padding: MediaQuery.viewPaddingOf(context).copyWith(top: 0),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/pages/login/view.dart
+++ b/lib/pages/login/view.dart
@@ -8,7 +8,7 @@ import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/login/controller.dart';
-import 'package:PiliPlus/pages/login/third_party_login_view.dart';
+import 'package:PiliPlus/pages/login/web_login_view.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
 import 'package:PiliPlus/utils/extension/widget_ext.dart';
 import 'package:PiliPlus/utils/image_utils.dart';
@@ -213,7 +213,7 @@ class _LoginPageState extends State<LoginPage> {
         if (Platform.isAndroid) ...[
           const SizedBox(height: 8),
           TextButton.icon(
-            onPressed: _openThirdPartyLogin,
+            onPressed: _openWebLogin,
             icon: const Icon(Icons.language_outlined),
             label: const Text('网页登录获取 Cookie'),
           ),
@@ -222,7 +222,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
-  Future<void> _openThirdPartyLogin() async {
+  Future<void> _openWebLogin() async {
     final loggedIn = await showModalBottomSheet<bool>(
       context: context,
       isScrollControlled: true,
@@ -241,7 +241,7 @@ class _LoginPageState extends State<LoginPage> {
               ),
             ),
             Expanded(
-              child: ThirdPartyLoginView(
+              child: WebLoginView(
                 controller: _loginPageCtr,
                 padding: MediaQuery.viewPaddingOf(context).copyWith(top: 0),
               ),

--- a/lib/pages/login/view.dart
+++ b/lib/pages/login/view.dart
@@ -222,8 +222,8 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
-  Future<void> _openThirdPartyLogin() {
-    return showModalBottomSheet<void>(
+  Future<void> _openThirdPartyLogin() async {
+    final loggedIn = await showModalBottomSheet<bool>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
@@ -237,7 +237,7 @@ class _LoginPageState extends State<LoginPage> {
               trailing: IconButton(
                 tooltip: '关闭',
                 icon: const Icon(Icons.close),
-                onPressed: Get.back,
+                onPressed: () => Navigator.of(context).pop(false),
               ),
             ),
             Expanded(
@@ -250,6 +250,9 @@ class _LoginPageState extends State<LoginPage> {
         ),
       ),
     );
+    if (loggedIn == true && mounted) {
+      Get.back();
+    }
   }
 
   Widget loginByPassword(ThemeData theme) {

--- a/lib/pages/login/web_login_view.dart
+++ b/lib/pages/login/web_login_view.dart
@@ -9,8 +9,8 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:get/get.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class ThirdPartyLoginView extends StatefulWidget {
-  const ThirdPartyLoginView({
+class WebLoginView extends StatefulWidget {
+  const WebLoginView({
     super.key,
     required this.controller,
     required this.padding,
@@ -20,10 +20,10 @@ class ThirdPartyLoginView extends StatefulWidget {
   final EdgeInsets padding;
 
   @override
-  State<ThirdPartyLoginView> createState() => _ThirdPartyLoginViewState();
+  State<WebLoginView> createState() => _WebLoginViewState();
 }
 
-class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
+class _WebLoginViewState extends State<WebLoginView>
     with WidgetsBindingObserver {
   static const _desktopUserAgent = BrowserUa.pcChrome;
 
@@ -130,7 +130,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
   }
 
   Future<void> _detectLoginStatus({bool showResultToast = false}) async {
-    final isLoggedIn = await widget.controller.importWebLoginCookies(
+    final isLoggedIn = await widget.controller.importWebLoginAccount(
       showResultToast: showResultToast,
     );
     if (!mounted || !isLoggedIn) {
@@ -142,7 +142,7 @@ class _ThirdPartyLoginViewState extends State<ThirdPartyLoginView>
   @override
   Widget build(BuildContext context) {
     if (!Platform.isAndroid) {
-      return const Center(child: Text('第三方网页登录仅支持 Android APK'));
+      return const Center(child: Text('网页登录仅支持 Android APK'));
     }
 
     return Column(


### PR DESCRIPTION
由于当前apk客户端，使用cookie登录需要手动F12在web处理cookie信息，程序繁琐，对于无法使用二维码而使用第三方登录的账号，便捷性较低。

所以添加了第三方登录的支持。已经测试登录回调，like，评论点赞点踩，coin，collect，观看记录功能正常，测试平台为arm64_v8a.

PR的代码变更：
ThirdPartyLoginView-使用桌面端UA和指纹以获取正确页面，支持企鹅/小而美/大眼第三方OAuth登录。自动获取cookie登陆中五字段内容：SESSDATA, DedeUserID, bili_jct，DedeUserID__ckMd5, sid。
Cookie-Only Accounts-互动逻辑由于缺少access_key直接加入cookie的业务逻辑会失效，所以新增了状态判断，用于触发like, coin的web fallback回调。因为web没有视频点踩，所以变更了提示。

由于没有扫码/短信登录用户，没法测试这一部分的业务逻辑状况。但从代码流程校验来说是没有破坏的。

测试图片：
-登录流程：
cookie登录
<img width="1440" height="3168" alt="3ed3d562f9fbd58e5ef277857b8ce9e3" src="https://github.com/user-attachments/assets/145a944c-aaa9-47f3-affc-797b5f6ad2f6" />
呼出浏览器
<img width="1280" height="2816" alt="1b0579526a6cb95f20a64ba335ee59fe" src="https://github.com/user-attachments/assets/c222827e-5a9e-4281-ad6c-d3ab41857381" />
选择第三方企鹅登录
<img width="1440" height="3168" alt="f1e97e6b748f6a70bc78e8d3d01298e4" src="https://github.com/user-attachments/assets/ef4d32fa-b852-4f49-abe9-f26d849052cd" />
扫码登录
<img width="1440" height="3168" alt="ae70d08b0a522ea1a5f018e011f71bd4" src="https://github.com/user-attachments/assets/846d9f39-f07a-4a80-861a-c9d1678a0259" />
获取cookie
<img width="1280" height="2816" alt="2312d0759040932c261d8c8f302a30aa" src="https://github.com/user-attachments/assets/9dd34ad8-1ce4-4c4b-8160-183a85206831" />
登录成功
<img width="1280" height="2816" alt="0ff4d45256ecb3e5c027337c4f54dd1d" src="https://github.com/user-attachments/assets/18aa9236-f544-4243-8ddd-6c5e0313fcf4" />
-互动业务测试
点赞
<img width="1440" height="3168" alt="9772fcc981c5c2cdb92eb0fe46bccd76" src="https://github.com/user-attachments/assets/9f636f7e-5912-46d9-8ef6-131f583e8838" />
<img width="1280" height="2816" alt="184b2a1aea3ebbcf8105fff8ae6c0912" src="https://github.com/user-attachments/assets/8b5b57ea-0ed1-4ff1-8c6a-57d2b48bcdc8" />
私信
<img width="1280" height="2816" alt="282c0160b6f6811682c1c2e4847a18f2" src="https://github.com/user-attachments/assets/58e0b54d-fccb-4669-b2a2-4406c442e887" />

消息业务四小项功能可见，但是消息页面主页无法使用，这个可能得TV登录方法/二维码扫码登录才可以。web端用的5项鉴权无法覆盖消息接口的请求，原有逻辑可能得重新移植。