### PR TITLE
feat: 视频评论图片区改为`图片总览 + 单图详情`

### DIFF
--- a/lib/common/widgets/image_grid/image_grid_view.dart
+++ b/lib/common/widgets/image_grid/image_grid_view.dart
@@ -176,6 +176,11 @@ class ImageGridView extends StatelessWidget {
         ),
         PopupMenuItem(
           height: 42,
+          onTap: () => ImageUtils.copyImg(item.url),
+          child: const Text('复制图片', style: TextStyle(fontSize: 14)),
+        ),
+        PopupMenuItem(
+          height: 42,
           onTap: () => ImageUtils.downloadImg([item.url]),
           child: const Text('保存图片', style: TextStyle(fontSize: 14)),
         ),

--- a/lib/common/widgets/image_grid/image_grid_view.dart
+++ b/lib/common/widgets/image_grid/image_grid_view.dart
@@ -66,17 +66,22 @@ class ImageGridView extends StatelessWidget {
     super.key,
     required this.picArr,
     this.allPicArr,
+    this.allPicArrGetter,
     this.onViewImage,
     this.fullScreen = false,
   });
 
   final List<ImageModel> picArr;
   final List<ImageModel>? allPicArr;
+  final List<ImageModel>? Function()? allPicArrGetter;
   final VoidCallback? onViewImage;
   final bool fullScreen;
 
   static bool horizontalPreview = Pref.horizontalPreview;
   static final _regex = RegExp(r'/videoV|/dynamicDetail$|/articlePage');
+
+  List<ImageModel> get _allPicArr =>
+      allPicArr ?? allPicArrGetter?.call() ?? picArr;
 
   List<SourceModel> _toSources(List<ImageModel> list) {
     return list
@@ -95,7 +100,7 @@ class ImageGridView extends StatelessWidget {
 
   void _onTap(BuildContext context, int index) {
     final imgList = _toSources(picArr);
-    final allImgList = _toSources(allPicArr ?? picArr);
+    final allImgList = _toSources(_allPicArr);
     if (horizontalPreview &&
         !fullScreen &&
         Get.currentRoute.startsWith(_regex) &&
@@ -152,7 +157,8 @@ class ImageGridView extends StatelessWidget {
     HapticFeedback.mediumImpact();
     final item = picArr[index];
     final imgList = _toSources(picArr);
-    final allImgList = _toSources(allPicArr ?? picArr);
+    final allImgList = _toSources(_allPicArr);
+    final hasAllPicArr = allPicArr != null || allPicArrGetter != null;
     showMenu(
       context: context,
       position: PageUtils.menuPosition(offset),
@@ -173,7 +179,7 @@ class ImageGridView extends StatelessWidget {
           onTap: () => ImageUtils.downloadImg([item.url]),
           child: const Text('保存图片', style: TextStyle(fontSize: 14)),
         ),
-        if (allPicArr != null)
+        if (hasAllPicArr)
           PopupMenuItem(
             height: 42,
             onTap: () => PageUtils.imageView(
@@ -190,7 +196,7 @@ class ImageGridView extends StatelessWidget {
             onTap: () => PageUtils.launchURL(item.url),
             child: const Text('网页打开', style: TextStyle(fontSize: 14)),
           )
-        else if (allPicArr != null)
+        else if (hasAllPicArr)
           PopupMenuItem(
             height: 42,
             onTap: () => ImageUtils.downloadImg(

--- a/lib/common/widgets/image_grid/image_grid_view.dart
+++ b/lib/common/widgets/image_grid/image_grid_view.dart
@@ -276,12 +276,13 @@ class ImageGridView extends StatelessWidget {
             if (!item.isLongPic) {
               child = Hero(tag: '${item.url}$hashCode', child: child);
             }
-            return Semantics(
+            child = Semantics(
               label: '图片，第 ${index + 1} 张，共 ${picArr.length} 张',
               button: true,
               onTap: () => _onTap(context, index),
-              child: LayoutId(id: index, child: child),
+              child: child,
             );
+            return LayoutId(id: index, child: child);
           });
         },
       ),

--- a/lib/common/widgets/image_grid/image_grid_view.dart
+++ b/lib/common/widgets/image_grid/image_grid_view.dart
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of PiliPlus
  *
  * PiliPlus is free software: you can redistribute it and/or modify
@@ -30,10 +30,10 @@ import 'package:PiliPlus/utils/image_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:PiliPlus/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
-import 'package:get/get_core/src/get_main.dart';
-import 'package:get/get_navigation/src/extension_navigation.dart';
+import 'package:get/get.dart';
 
 class ImageModel {
   ImageModel({
@@ -65,31 +65,37 @@ class ImageGridView extends StatelessWidget {
   const ImageGridView({
     super.key,
     required this.picArr,
+    this.allPicArr,
     this.onViewImage,
     this.fullScreen = false,
   });
 
   final List<ImageModel> picArr;
+  final List<ImageModel>? allPicArr;
   final VoidCallback? onViewImage;
   final bool fullScreen;
 
   static bool horizontalPreview = Pref.horizontalPreview;
   static final _regex = RegExp(r'/videoV|/dynamicDetail$|/articlePage');
 
+  List<SourceModel> _toSources(List<ImageModel> list) {
+    return list
+        .map(
+          (item) => SourceModel(
+            sourceType: item.isLivePhoto ? .livePhoto : .networkImage,
+            url: item.url,
+            liveUrl: item.isLivePhoto ? item.liveUrl : null,
+            width: item.isLivePhoto ? item.width.toInt() : null,
+            height: item.isLivePhoto ? item.height.toInt() : null,
+            isLongPic: item.isLongPic,
+          ),
+        )
+        .toList();
+  }
+
   void _onTap(BuildContext context, int index) {
-    final imgList = picArr.map(
-      (item) {
-        bool isLive = item.isLivePhoto;
-        return SourceModel(
-          sourceType: isLive ? .livePhoto : .networkImage,
-          url: item.url,
-          liveUrl: isLive ? item.liveUrl : null,
-          width: isLive ? item.width.toInt() : null,
-          height: isLive ? item.height.toInt() : null,
-          isLongPic: item.isLongPic,
-        );
-      },
-    ).toList();
+    final imgList = _toSources(picArr);
+    final allImgList = _toSources(allPicArr ?? picArr);
     if (horizontalPreview &&
         !fullScreen &&
         Get.currentRoute.startsWith(_regex) &&
@@ -101,6 +107,8 @@ class ImageGridView extends StatelessWidget {
           scaffoldState,
           imgList,
           index,
+          allSources: allImgList,
+          tag: hashCode.toString(),
         );
         return;
       }
@@ -108,6 +116,7 @@ class ImageGridView extends StatelessWidget {
     PageUtils.imageView(
       initialPage: index,
       imgList: imgList,
+      allSources: allImgList,
       tag: hashCode.toString(),
     );
   }
@@ -142,6 +151,8 @@ class ImageGridView extends StatelessWidget {
   void _showMenu(BuildContext context, int index, Offset offset) {
     HapticFeedback.mediumImpact();
     final item = picArr[index];
+    final imgList = _toSources(picArr);
+    final allImgList = _toSources(allPicArr ?? picArr);
     showMenu(
       context: context,
       position: PageUtils.menuPosition(offset),
@@ -154,25 +165,37 @@ class ImageGridView extends StatelessWidget {
           ),
         PopupMenuItem(
           height: 42,
-          onTap: () => ImageUtils.copyImg(item.url),
-          child: const Text('复制图片', style: TextStyle(fontSize: 14)),
+          onTap: () => Utils.copyText(item.url),
+          child: const Text('复制链接', style: TextStyle(fontSize: 14)),
         ),
         PopupMenuItem(
           height: 42,
           onTap: () => ImageUtils.downloadImg([item.url]),
           child: const Text('保存图片', style: TextStyle(fontSize: 14)),
         ),
+        if (allPicArr != null)
+          PopupMenuItem(
+            height: 42,
+            onTap: () => PageUtils.imageView(
+              initialPage: index,
+              imgList: imgList,
+              allSources: allImgList,
+              tag: hashCode.toString(),
+            ),
+            child: const Text('查看所有图片', style: TextStyle(fontSize: 14)),
+          ),
         if (PlatformUtils.isDesktop)
           PopupMenuItem(
             height: 42,
             onTap: () => PageUtils.launchURL(item.url),
             child: const Text('网页打开', style: TextStyle(fontSize: 14)),
           )
-        else if (picArr.length > 1)
+        else if (allPicArr != null)
           PopupMenuItem(
             height: 42,
-            onTap: () =>
-                ImageUtils.downloadImg(picArr.map((item) => item.url).toList()),
+            onTap: () => ImageUtils.downloadImg(
+              allImgList.map((item) => item.url).toList(),
+            ),
             child: const Text('保存全部', style: TextStyle(fontSize: 14)),
           ),
         if (item.isLivePhoto)
@@ -209,13 +232,11 @@ class ImageGridView extends StatelessWidget {
         builder: (BuildContext context, ImageGridInfo info) {
           final width = info.size.width;
           final height = info.size.height;
-          late final placeHolder = Container(
+          final placeHolder = Container(
             width: width,
             height: height,
             decoration: BoxDecoration(
-              color: ColorScheme.of(
-                context,
-              ).onInverseSurface.withValues(alpha: 0.4),
+              color: ColorScheme.of(context).onInverseSurface.withValues(alpha: 0.4),
             ),
             child: Image.asset(
               Assets.loading,
@@ -225,13 +246,8 @@ class ImageGridView extends StatelessWidget {
             ),
           );
           return List.generate(picArr.length, (index) {
-            void onTap() => _onTap(context, index);
             final item = picArr[index];
-            final borderRadius = _borderRadius(
-              info.column,
-              picArr.length,
-              index,
-            );
+            final borderRadius = _borderRadius(info.column, picArr.length, index);
             Widget child = Stack(
               clipBehavior: Clip.none,
               alignment: Alignment.center,
@@ -254,13 +270,12 @@ class ImageGridView extends StatelessWidget {
             if (!item.isLongPic) {
               child = Hero(tag: '${item.url}$hashCode', child: child);
             }
-            child = Semantics(
+            return Semantics(
               label: '图片，第 ${index + 1} 张，共 ${picArr.length} 张',
               button: true,
-              onTap: onTap,
-              child: child,
+              onTap: () => _onTap(context, index),
+              child: LayoutId(id: index, child: child),
             );
-            return LayoutId(id: index, child: child);
           });
         },
       ),

--- a/lib/common/widgets/image_viewer/gallery_overview_view.dart
+++ b/lib/common/widgets/image_viewer/gallery_overview_view.dart
@@ -1,0 +1,309 @@
+﻿import 'dart:io' show File;
+
+import 'package:PiliPlus/common/assets.dart';
+import 'package:PiliPlus/common/style.dart';
+import 'package:PiliPlus/common/widgets/badge.dart';
+import 'package:PiliPlus/common/widgets/image_viewer/gallery_viewer.dart';
+import 'package:PiliPlus/common/widgets/image_viewer/hero_dialog_route.dart';
+import 'package:PiliPlus/common/widgets/select_mask.dart';
+import 'package:PiliPlus/models/common/badge_type.dart';
+import 'package:PiliPlus/models/common/image_preview_type.dart';
+import 'package:PiliPlus/utils/global_data.dart';
+import 'package:PiliPlus/utils/image_utils.dart';
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class GalleryOverviewView extends StatefulWidget {
+  const GalleryOverviewView({
+    super.key,
+    required this.sources,
+    this.initIndex = 0,
+    this.tag = '',
+  });
+
+  final List<SourceModel> sources;
+  final int initIndex;
+  final String tag;
+
+  @override
+  State<GalleryOverviewView> createState() => _GalleryOverviewViewState();
+}
+
+class _GalleryOverviewViewState extends State<GalleryOverviewView> {
+  static const int _crossAxisCount = 3;
+  static const double _spacing = 4;
+  final _scrollController = ScrollController();
+  final Set<int> _selected = <int>{};
+  bool _enableMultiSelect = false;
+  bool _initialJumpDone = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _syncMultiSelect(bool value) {
+    if (_enableMultiSelect == value) return;
+    setState(() {
+      _enableMultiSelect = value;
+      if (!value) _selected.clear();
+    });
+  }
+
+  void _toggleSelect(int index) {
+    setState(() {
+      _enableMultiSelect = true;
+      if (!_selected.add(index)) {
+        _selected.remove(index);
+      }
+      if (_selected.isEmpty) {
+        _enableMultiSelect = false;
+      }
+    });
+  }
+
+  void _selectAll() {
+    final isAllSelected =
+        _selected.length == widget.sources.length && widget.sources.isNotEmpty;
+    setState(() {
+      if (isAllSelected) {
+        _enableMultiSelect = false;
+        _selected.clear();
+      } else {
+        _enableMultiSelect = true;
+        _selected
+          ..clear()
+          ..addAll(List.generate(widget.sources.length, (index) => index));
+      }
+    });
+  }
+
+  Future<void> _downloadSelected() async {
+    if (_selected.isEmpty) return;
+    final urls = <String>[];
+    final livePhotos = <SourceModel>[];
+    for (final index in _selected) {
+      final item = widget.sources[index];
+      if (item.sourceType == SourceType.livePhoto && item.liveUrl != null) {
+        livePhotos.add(item);
+      } else {
+        urls.add(item.url);
+      }
+    }
+    if (urls.isNotEmpty) {
+      await ImageUtils.downloadImg(urls);
+    }
+    for (final item in livePhotos) {
+      await ImageUtils.downloadLivePhoto(
+        url: item.url,
+        liveUrl: item.liveUrl!,
+        width: item.width ?? 1,
+        height: item.height ?? 1,
+      );
+    }
+    if (!mounted) return;
+    setState(() {
+      _enableMultiSelect = false;
+      _selected.clear();
+    });
+  }
+
+  Future<void> _openViewer(int index) async {
+    await Get.key.currentState!.push<void>(
+      HeroDialogRoute(
+        pageBuilder: (context, animation, secondaryAnimation) => GalleryViewer(
+          sources: widget.sources,
+          allSources: widget.sources,
+          initIndex: index,
+          quality: GlobalData().imgQuality,
+          tag: '${widget.tag}#all',
+        ),
+      ),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialJumpDone || widget.sources.isEmpty) return;
+    _initialJumpDone = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      final mediaQuery = MediaQuery.of(context);
+      final horizontalPadding = 24.0;
+      final spacingWidth = _spacing * (_crossAxisCount - 1);
+      final tileExtent =
+          (mediaQuery.size.width -
+              mediaQuery.padding.left -
+              mediaQuery.padding.right -
+              horizontalPadding -
+              spacingWidth) /
+          _crossAxisCount;
+      final row = widget.initIndex ~/ _crossAxisCount;
+      final offset = row * (tileExtent + _spacing);
+      final max = _scrollController.position.maxScrollExtent;
+      _scrollController.jumpTo(offset.clamp(0.0, max));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final padding = MediaQuery.viewPaddingOf(context);
+    final size = MediaQuery.sizeOf(context);
+    final horizontalPadding = 24.0;
+    final spacingWidth = _spacing * (_crossAxisCount - 1);
+    final tileExtent =
+        (size.width -
+            padding.left -
+            padding.right -
+            horizontalPadding -
+            spacingWidth) /
+        _crossAxisCount;
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: _enableMultiSelect ? '取消选择' : '返回',
+          onPressed: () {
+            if (_enableMultiSelect) {
+              _syncMultiSelect(false);
+            } else {
+              Get.back<void>();
+            }
+          },
+          icon: Icon(
+            _enableMultiSelect ? Icons.close_outlined : Icons.arrow_back_ios_new,
+          ),
+        ),
+        title: Text(
+          _enableMultiSelect
+              ? '已选 ${_selected.length}/${widget.sources.length}'
+              : '图片总览',
+        ),
+        actions: [
+          if (_enableMultiSelect)
+            IconButton(
+              tooltip:
+                  _selected.length == widget.sources.length ? '取消全选' : '全选',
+              onPressed: _selectAll,
+              icon: const Icon(Icons.select_all_outlined),
+            )
+          else
+            IconButton(
+              tooltip: '多选',
+              onPressed: () => _syncMultiSelect(true),
+              icon: const Icon(Icons.checklist_rtl),
+            ),
+          if (_enableMultiSelect)
+            IconButton(
+              tooltip: '下载',
+              onPressed: _selected.isEmpty ? null : _downloadSelected,
+              icon: const Icon(Icons.download_outlined),
+            ),
+          const SizedBox(width: 6),
+        ],
+      ),
+      body: GridView.builder(
+        controller: _scrollController,
+        padding: EdgeInsets.fromLTRB(12, 12, 12, 12 + padding.bottom),
+        itemCount: widget.sources.length,
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: _crossAxisCount,
+          crossAxisSpacing: _spacing,
+          mainAxisSpacing: _spacing,
+          childAspectRatio: 1,
+        ),
+        itemBuilder: (context, index) {
+          final item = widget.sources[index];
+          final checked = _selected.contains(index);
+          final borderRadius = Style.mdRadius;
+          final tile = Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: borderRadius,
+              onTap: () {
+                if (_enableMultiSelect) {
+                  _toggleSelect(index);
+                } else {
+                  _openViewer(index);
+                }
+              },
+              onLongPress: () => _toggleSelect(index),
+              child: Stack(
+                clipBehavior: Clip.none,
+                alignment: Alignment.center,
+                children: [
+                  Positioned.fill(
+                    child: ClipRRect(
+                      borderRadius: borderRadius,
+                      child: item.sourceType == SourceType.fileImage
+                          ? Image.file(
+                              File(item.url),
+                              width: tileExtent,
+                              height: tileExtent,
+                              fit: BoxFit.cover,
+                              filterQuality: FilterQuality.high,
+                              errorBuilder: (_, __, ___) => Container(
+                                color: theme.colorScheme.onInverseSurface
+                                    .withValues(alpha: 0.4),
+                                alignment: Alignment.center,
+                                child: const Icon(Icons.broken_image_outlined),
+                              ),
+                            )
+                          : CachedNetworkImage(
+                              imageUrl: ImageUtils.thumbnailUrl(item.url, 100),
+                              width: tileExtent,
+                              height: tileExtent,
+                              fit: BoxFit.cover,
+                              alignment: item.isLongPic
+                                  ? Alignment.topCenter
+                                  : Alignment.center,
+                              filterQuality: FilterQuality.high,
+                              placeholder: (_, __) => Container(
+                                color: theme.colorScheme.onInverseSurface
+                                    .withValues(alpha: 0.4),
+                                alignment: Alignment.center,
+                                child: Image.asset(Assets.loading, width: 28, height: 28),
+                              ),
+                              errorWidget: (_, __, ___) => Container(
+                                color: theme.colorScheme.onInverseSurface
+                                    .withValues(alpha: 0.4),
+                                alignment: Alignment.center,
+                                child: const Icon(Icons.broken_image_outlined),
+                              ),
+                            ),
+                    ),
+                  ),
+                  if (item.sourceType == SourceType.livePhoto)
+                    const PBadge(
+                      text: 'Live',
+                      right: 8,
+                      bottom: 8,
+                      type: PBadgeType.gray,
+                    )
+                  else if (item.isLongPic)
+                    const PBadge(text: '长图', right: 8, bottom: 8),
+                  Positioned.fill(
+                    child: selectMask(
+                      theme.colorScheme,
+                      checked,
+                      borderRadius: borderRadius,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+          return Semantics(
+            label: '图片，第 ${index + 1} 张，共 ${widget.sources.length} 张',
+            button: true,
+            child: Hero(tag: '${item.url}${widget.tag}#all', child: tile),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/image_viewer/gallery_viewer.dart
+++ b/lib/common/widgets/image_viewer/gallery_viewer.dart
@@ -526,6 +526,14 @@ class _GalleryViewerState extends State<GalleryViewer>
             ListTile(
               onTap: () {
                 Get.back();
+                ImageUtils.copyImg(item.url);
+              },
+              dense: true,
+              title: const Text('复制图片', style: TextStyle(fontSize: 14)),
+            ),
+            ListTile(
+              onTap: () {
+                Get.back();
                 ImageUtils.downloadImg([item.url]);
               },
               dense: true,
@@ -584,6 +592,11 @@ class _GalleryViewerState extends State<GalleryViewer>
           height: 42,
           onTap: () => Utils.copyText(item.url),
           child: const Text('复制链接', style: TextStyle(fontSize: 14)),
+        ),
+        PopupMenuItem(
+          height: 42,
+          onTap: () => ImageUtils.copyImg(item.url),
+          child: const Text('复制图片', style: TextStyle(fontSize: 14)),
         ),
         PopupMenuItem(
           height: 42,

--- a/lib/common/widgets/image_viewer/gallery_viewer.dart
+++ b/lib/common/widgets/image_viewer/gallery_viewer.dart
@@ -513,7 +513,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   ImageUtils.onShareImg(item.url);
                 },
                 dense: true,
-                title: const Text('鍒嗕韩', style: TextStyle(fontSize: 14)),
+                title: const Text('分享', style: TextStyle(fontSize: 14)),
               ),
             ListTile(
               onTap: () {
@@ -521,7 +521,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                 Utils.copyText(item.url);
               },
               dense: true,
-              title: const Text('澶嶅埗閾炬帴', style: TextStyle(fontSize: 14)),
+              title: const Text('复制链接', style: TextStyle(fontSize: 14)),
             ),
             ListTile(
               onTap: () {
@@ -529,7 +529,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                 ImageUtils.downloadImg([item.url]);
               },
               dense: true,
-              title: const Text('淇濆瓨鍥剧墖', style: TextStyle(fontSize: 14)),
+              title: const Text('保存图片', style: TextStyle(fontSize: 14)),
             ),
             if (canViewAllMedia)
               ListTile(
@@ -538,7 +538,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   _viewAllMedia();
                 },
                 dense: true,
-                title: const Text('鏌ョ湅鎵€鏈夊浘鐗?, style: TextStyle(fontSize: 14)),
+                title: const Text('查看所有图片', style: TextStyle(fontSize: 14)),
               ),
             if (PlatformUtils.isDesktop)
               ListTile(
@@ -547,7 +547,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   PageUtils.launchURL(item.url);
                 },
                 dense: true,
-                title: const Text('缃戦〉鎵撳紑', style: TextStyle(fontSize: 14)),
+                title: const Text('网页打开', style: TextStyle(fontSize: 14)),
               ),
             if (item.sourceType == SourceType.livePhoto)
               ListTile(
@@ -562,7 +562,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                 },
                 dense: true,
                 title: Text(
-                  '淇濆瓨${Platform.isIOS ? ' Live Photo' : '瑙嗛'}',
+                  '保存${Platform.isIOS ? ' Live Photo' : '视频'}',
                   style: const TextStyle(fontSize: 14),
                 ),
               ),
@@ -583,23 +583,23 @@ class _GalleryViewerState extends State<GalleryViewer>
         PopupMenuItem(
           height: 42,
           onTap: () => Utils.copyText(item.url),
-          child: const Text('澶嶅埗閾炬帴', style: TextStyle(fontSize: 14)),
+          child: const Text('复制链接', style: TextStyle(fontSize: 14)),
         ),
         PopupMenuItem(
           height: 42,
           onTap: () => ImageUtils.downloadImg([item.url]),
-          child: const Text('淇濆瓨鍥剧墖', style: TextStyle(fontSize: 14)),
+          child: const Text('保存图片', style: TextStyle(fontSize: 14)),
         ),
         if (canViewAllMedia)
           PopupMenuItem(
             height: 42,
             onTap: _viewAllMedia,
-            child: const Text('鏌ョ湅鎵€鏈夊浘鐗?, style: TextStyle(fontSize: 14)),
+            child: const Text('查看所有图片', style: TextStyle(fontSize: 14)),
           ),
         PopupMenuItem(
           height: 42,
           onTap: () => PageUtils.launchURL(item.url),
-          child: const Text('缃戦〉鎵撳紑', style: TextStyle(fontSize: 14)),
+          child: const Text('网页打开', style: TextStyle(fontSize: 14)),
         ),
         if (item.sourceType == SourceType.livePhoto)
           PopupMenuItem(
@@ -610,7 +610,7 @@ class _GalleryViewerState extends State<GalleryViewer>
               width: item.width!,
               height: item.height!,
             ),
-            child: const Text('淇濆瓨瑙嗛', style: TextStyle(fontSize: 14)),
+            child: const Text('保存视频', style: TextStyle(fontSize: 14)),
           ),
       ],
     );

--- a/lib/common/widgets/image_viewer/gallery_viewer.dart
+++ b/lib/common/widgets/image_viewer/gallery_viewer.dart
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of PiliPlus
  *
  * PiliPlus is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@ import 'dart:io' show File, Platform;
 import 'package:PiliPlus/common/widgets/colored_box_transition.dart';
 import 'package:PiliPlus/common/widgets/flutter/page/page_view.dart';
 import 'package:PiliPlus/common/widgets/gesture/image_horizontal_drag_gesture_recognizer.dart';
+import 'package:PiliPlus/common/widgets/image_viewer/gallery_overview_view.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/image.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/loading_indicator.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/viewer.dart';
@@ -56,6 +57,7 @@ class GalleryViewer extends StatefulWidget {
     this.maxScale = 8.0,
     required this.quality,
     required this.sources,
+    this.allSources,
     this.initIndex = 0,
     this.onPageChanged,
     this.tag = '',
@@ -65,6 +67,7 @@ class GalleryViewer extends StatefulWidget {
   final double maxScale;
   final int quality;
   final List<SourceModel> sources;
+  final List<SourceModel>? allSources;
   final int initIndex;
   final ValueChanged<int>? onPageChanged;
   final String tag;
@@ -80,30 +83,22 @@ class _GalleryViewerState extends State<GalleryViewer>
   late final RxInt _currIndex;
   GlobalKey? _key;
   EdgeInsets? _padding;
-
   late bool _hasInit = false;
   Player? _player;
   VideoController? _videoController;
-
   late final PageController _pageController;
-
   late final TapGestureRecognizer _tapGestureRecognizer;
   late final DoubleTapGestureRecognizer _doubleTapGestureRecognizer;
-  late final ImageHorizontalDragGestureRecognizer
-  _horizontalDragGestureRecognizer;
+  late final ImageHorizontalDragGestureRecognizer _horizontalDragGestureRecognizer;
   late final LongPressGestureRecognizer _longPressGestureRecognizer;
-
   late final AnimationController _animateController;
   late final Animation<Color?> _opacityAnimation;
   double dx = 0, dy = 0;
-
   Offset _offset = Offset.zero;
   bool _dragging = false;
 
   String _getActualUrl(String url) {
-    return _quality != 100
-        ? ImageUtils.thumbnailUrl(url, _quality)
-        : url.http2https;
+    return _quality != 100 ? ImageUtils.thumbnailUrl(url, _quality) : url.http2https;
   }
 
   Future<void> _initPlayer() async {
@@ -130,17 +125,13 @@ class _GalleryViewerState extends State<GalleryViewer>
     _currIndex = widget.initIndex.obs;
     final item = widget.sources[widget.initIndex];
     _playIfNeeded(item);
-
     if (!item.isLongPic) {
       _key = GlobalKey();
       WidgetsBinding.instance.addPostFrameCallback((_) => _key = null);
     }
-
     _pageController = PageController(initialPage: widget.initIndex);
-
     final gestureSettings = MediaQuery.maybeGestureSettingsOf(Get.context!);
     _tapGestureRecognizer = TapGestureRecognizer()
-      // ..onTap = _onTap
       ..gestureSettings = gestureSettings;
     if (PlatformUtils.isDesktop) {
       _tapGestureRecognizer.onSecondaryTapUp = _showDesktopMenu;
@@ -152,25 +143,17 @@ class _GalleryViewerState extends State<GalleryViewer>
     _longPressGestureRecognizer = LongPressGestureRecognizer()
       ..onLongPress = _onLongPress
       ..gestureSettings = gestureSettings;
-
     Future.delayed(const Duration(milliseconds: 300), () {
       if (mounted) {
         _tapGestureRecognizer.onTap = _onTap;
       }
     });
-
     _animateController = AnimationController(
-      duration: const Duration(
-        milliseconds: 750,
-      ), // reverse only if value <= 0.2
+      duration: const Duration(milliseconds: 750),
       vsync: this,
     );
-
     _opacityAnimation = _animateController.drive(
-      ColorTween(
-        begin: Colors.black,
-        end: Colors.transparent,
-      ),
+      ColorTween(begin: Colors.black, end: Colors.transparent),
     );
   }
 
@@ -204,9 +187,7 @@ class _GalleryViewerState extends State<GalleryViewer>
       if (_hideSystemBar) {
         tmpPadding = padding;
         hideSystemBar()!.whenComplete(
-          () => WidgetsBinding.instance.addPostFrameCallback(
-            (_) => tmpPadding = null,
-          ),
+          () => WidgetsBinding.instance.addPostFrameCallback((_) => tmpPadding = null),
         );
       }
     }
@@ -214,19 +195,13 @@ class _GalleryViewerState extends State<GalleryViewer>
 
   Matrix4 _onTransform(double val) {
     final scale = val.lerp(1.0, 0.25);
-
-    // Matrix4.identity()
-    //   ..translateByDouble(size.width / 2, size.height / 2, 0, 1)
-    //   ..translateByDouble(size.width * val * dx, size.height * val * dy, 0, 1)
-    //   ..scaleByDouble(scale, scale, scale, 1)
-    //   ..translateByDouble(-size.width / 2, -size.height / 2, 0, 1);
-
     final tmp = (1.0 - scale) / 2.0;
-    return Matrix4.diagonal3Values(scale, scale, scale)..setTranslationRaw(
-      _containerSize.width * (val * dx + tmp),
-      _containerSize.height * (val * dy + tmp),
-      0,
-    );
+    return Matrix4.diagonal3Values(scale, scale, scale)
+      ..setTranslationRaw(
+        _containerSize.width * (val * dx + tmp),
+        _containerSize.height * (val * dy + tmp),
+        0,
+      );
   }
 
   void _updateMoveAnimation() {
@@ -240,7 +215,6 @@ class _GalleryViewerState extends State<GalleryViewer>
 
   void _onDragStart(ScaleStartDetails details) {
     _dragging = true;
-
     if (_animateController.isAnimating) {
       _animateController.stop();
     } else {
@@ -251,25 +225,17 @@ class _GalleryViewerState extends State<GalleryViewer>
   }
 
   void _onDragUpdate(ScaleUpdateDetails details) {
-    if (!_dragging || _animateController.isAnimating) {
-      return;
-    }
-
+    if (!_dragging || _animateController.isAnimating) return;
     _offset += details.focalPointDelta;
     _updateMoveAnimation();
-
     if (!_animateController.isAnimating) {
       _animateController.value = _offset.dy.abs() / _containerSize.height;
     }
   }
 
   void _onDragEnd(ScaleEndDetails details) {
-    if (!_dragging || _animateController.isAnimating) {
-      return;
-    }
-
+    if (!_dragging || _animateController.isAnimating) return;
     _dragging = false;
-
     if (!_animateController.isDismissed) {
       if (_animateController.value > 0.2) {
         Get.back();
@@ -301,9 +267,7 @@ class _GalleryViewerState extends State<GalleryViewer>
     }
     Future.delayed(const Duration(milliseconds: 200), _currIndex.close);
     super.dispose();
-    if (_hideSystemBar) {
-      showSystemBar();
-    }
+    if (_hideSystemBar) showSystemBar();
   }
 
   void _onPointerDown(PointerDownEvent event) {
@@ -315,19 +279,19 @@ class _GalleryViewerState extends State<GalleryViewer>
   @override
   Widget build(BuildContext context) {
     return Listener(
-      behavior: .opaque,
+      behavior: HitTestBehavior.opaque,
       onPointerDown: _onPointerDown,
       child: Stack(
-        fit: .expand,
-        alignment: .center,
-        clipBehavior: .none,
+        fit: StackFit.expand,
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
         children: [
           ColoredBoxTransition(color: _opacityAnimation),
           LayoutBuilder(
             builder: (context, constraints) {
               _containerSize = constraints.biggest;
               return MatrixTransition(
-                alignment: .topLeft,
+                alignment: Alignment.topLeft,
                 animation: _animateController,
                 onTransform: _onTransform,
                 child: PageView<ImageHorizontalDragGestureRecognizer>.builder(
@@ -338,8 +302,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   ),
                   itemCount: widget.sources.length,
                   itemBuilder: _itemBuilder,
-                  horizontalDragGestureRecognizer: () =>
-                      _horizontalDragGestureRecognizer,
+                  horizontalDragGestureRecognizer: () => _horizontalDragGestureRecognizer,
                 ),
               );
             },
@@ -361,16 +324,13 @@ class _GalleryViewerState extends State<GalleryViewer>
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [
-              Colors.transparent,
-              Colors.black.withValues(alpha: 0.3),
-            ],
+            colors: [Colors.transparent, Colors.black.withValues(alpha: 0.3)],
           ),
         ),
         alignment: Alignment.center,
         child: Obx(
           () => Text(
-            "${_currIndex.value + 1}/${widget.sources.length}",
+            '${_currIndex.value + 1}/${widget.sources.length}',
             style: const TextStyle(color: Colors.white),
           ),
         ),
@@ -400,10 +360,7 @@ class _GalleryViewerState extends State<GalleryViewer>
       ? null
       : (int offset) {
           final currPage = _pageController.page?.round() ?? 0;
-          final nextPage = (currPage + offset).clamp(
-            0,
-            widget.sources.length - 1,
-          );
+          final nextPage = (currPage + offset).clamp(0, widget.sources.length - 1);
           if (nextPage != currPage) {
             _pageController.animateToPage(
               nextPage,
@@ -444,42 +401,29 @@ class _GalleryViewerState extends State<GalleryViewer>
           horizontalDragGestureRecognizer: _horizontalDragGestureRecognizer,
           onChangePage: _onChangePage,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-            if (wasSynchronouslyLoaded) {
-              return child;
-            }
+            if (wasSynchronouslyLoaded) return child;
             if (frame == null) {
               if (widget.quality == _quality) {
                 return child;
-              } else {
-                return Image(
-                  image: ResizeImage.resizeIfNeeded(
-                    _containerSize.width.cacheSize(context),
-                    null,
-                    CachedNetworkImageProvider(
-                      ImageUtils.thumbnailUrl(item.url, widget.quality),
-                    ),
-                  ),
-                  minScale: widget.minScale,
-                  maxScale: widget.maxScale,
-                  containerSize: _containerSize,
-                  onDragStart: null,
-                  onDragUpdate: null,
-                  onDragEnd: null,
-                  doubleTapGestureRecognizer: _doubleTapGestureRecognizer,
-                  horizontalDragGestureRecognizer:
-                      _horizontalDragGestureRecognizer,
-                  onChangePage: _onChangePage,
-                );
-                // final isLongPic = item.isLongPic;
-                // return CachedNetworkImage(
-                //   fadeInDuration: Duration.zero,
-                //   fadeOutDuration: Duration.zero,
-                //   // fit: isLongPic ? .fitWidth : null,
-                //   // alignment: isLongPic ? .topCenter : .center,
-                //   imageUrl: ImageUtils.thumbnailUrl(item.url, widget.quality),
-                //   placeholder: (_, _) => const SizedBox.expand(),
-                // );
               }
+              return Image(
+                image: ResizeImage.resizeIfNeeded(
+                  _containerSize.width.cacheSize(context),
+                  null,
+                  CachedNetworkImageProvider(
+                    ImageUtils.thumbnailUrl(item.url, widget.quality),
+                  ),
+                ),
+                minScale: widget.minScale,
+                maxScale: widget.maxScale,
+                containerSize: _containerSize,
+                onDragStart: null,
+                onDragUpdate: null,
+                onDragEnd: null,
+                doubleTapGestureRecognizer: _doubleTapGestureRecognizer,
+                horizontalDragGestureRecognizer: _horizontalDragGestureRecognizer,
+                onChangePage: _onChangePage,
+              );
             }
             return child;
           },
@@ -488,9 +432,7 @@ class _GalleryViewerState extends State<GalleryViewer>
           onDragUpdate: _onDragUpdate,
           onDragEnd: _onDragEnd,
         );
-        if (isLongPic) {
-          return child;
-        }
+        if (isLongPic) return child;
       case SourceType.livePhoto:
         child = Obx(
           key: _key,
@@ -504,8 +446,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   onDragUpdate: _onDragUpdate,
                   onDragEnd: _onDragEnd,
                   doubleTapGestureRecognizer: _doubleTapGestureRecognizer,
-                  horizontalDragGestureRecognizer:
-                      _horizontalDragGestureRecognizer,
+                  horizontalDragGestureRecognizer: _horizontalDragGestureRecognizer,
                   onChangePage: _onChangePage,
                   child: FittedBox(
                     child: SimpleVideo(
@@ -521,10 +462,34 @@ class _GalleryViewerState extends State<GalleryViewer>
   }
 
   void _onTap() {
-    EasyThrottle.throttle(
-      'VIEWER_TAP',
-      const Duration(milliseconds: 555),
-      Get.back,
+    EasyThrottle.throttle('VIEWER_TAP', const Duration(milliseconds: 555), Get.back);
+  }
+
+  bool get _canViewAllMedia =>
+      widget.allSources != null && !widget.tag.endsWith('#all');
+
+  int _matchAllSourceIndex(SourceModel item) {
+    final allSources = widget.allSources;
+    if (allSources == null || allSources.isEmpty) {
+      return _currIndex.value.clamp(0, widget.sources.length - 1);
+    }
+    final matchIndex = allSources.indexWhere(
+      (source) => source.url == item.url && source.liveUrl == item.liveUrl,
+    );
+    if (matchIndex != -1) return matchIndex;
+    return _currIndex.value.clamp(0, allSources.length - 1);
+  }
+
+  void _viewAllMedia() {
+    final allSources = widget.allSources;
+    if (!_canViewAllMedia || allSources == null || allSources.isEmpty) return;
+    final item = widget.sources[_currIndex.value];
+    Get.to(
+      () => GalleryOverviewView(
+        sources: allSources,
+        initIndex: _matchAllSourceIndex(item),
+        tag: '${widget.tag}#all',
+      ),
     );
   }
 
@@ -532,6 +497,7 @@ class _GalleryViewerState extends State<GalleryViewer>
     final item = widget.sources[_currIndex.value];
     if (item.sourceType == .fileImage) return;
     HapticFeedback.mediumImpact();
+    final canViewAllMedia = _canViewAllMedia;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -547,7 +513,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   ImageUtils.onShareImg(item.url);
                 },
                 dense: true,
-                title: const Text('分享', style: TextStyle(fontSize: 14)),
+                title: const Text('鍒嗕韩', style: TextStyle(fontSize: 14)),
               ),
             ListTile(
               onTap: () {
@@ -555,15 +521,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                 Utils.copyText(item.url);
               },
               dense: true,
-              title: const Text('复制链接', style: TextStyle(fontSize: 14)),
-            ),
-            ListTile(
-              onTap: () {
-                Get.back();
-                ImageUtils.copyImg(item.url);
-              },
-              dense: true,
-              title: const Text('复制图片', style: TextStyle(fontSize: 14)),
+              title: const Text('澶嶅埗閾炬帴', style: TextStyle(fontSize: 14)),
             ),
             ListTile(
               onTap: () {
@@ -571,8 +529,17 @@ class _GalleryViewerState extends State<GalleryViewer>
                 ImageUtils.downloadImg([item.url]);
               },
               dense: true,
-              title: const Text('保存图片', style: TextStyle(fontSize: 14)),
+              title: const Text('淇濆瓨鍥剧墖', style: TextStyle(fontSize: 14)),
             ),
+            if (canViewAllMedia)
+              ListTile(
+                onTap: () {
+                  Get.back();
+                  _viewAllMedia();
+                },
+                dense: true,
+                title: const Text('鏌ョ湅鎵€鏈夊浘鐗?, style: TextStyle(fontSize: 14)),
+              ),
             if (PlatformUtils.isDesktop)
               ListTile(
                 onTap: () {
@@ -580,18 +547,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                   PageUtils.launchURL(item.url);
                 },
                 dense: true,
-                title: const Text('网页打开', style: TextStyle(fontSize: 14)),
-              )
-            else if (widget.sources.length > 1)
-              ListTile(
-                onTap: () {
-                  Get.back();
-                  ImageUtils.downloadImg(
-                    widget.sources.map((item) => item.url).toList(),
-                  );
-                },
-                dense: true,
-                title: const Text('保存全部图片', style: TextStyle(fontSize: 14)),
+                title: const Text('缃戦〉鎵撳紑', style: TextStyle(fontSize: 14)),
               ),
             if (item.sourceType == SourceType.livePhoto)
               ListTile(
@@ -606,7 +562,7 @@ class _GalleryViewerState extends State<GalleryViewer>
                 },
                 dense: true,
                 title: Text(
-                  '保存${Platform.isIOS ? ' Live Photo' : '视频'}',
+                  '淇濆瓨${Platform.isIOS ? ' Live Photo' : '瑙嗛'}',
                   style: const TextStyle(fontSize: 14),
                 ),
               ),
@@ -619,6 +575,7 @@ class _GalleryViewerState extends State<GalleryViewer>
   void _showDesktopMenu(TapUpDetails details) {
     final item = widget.sources[_currIndex.value];
     if (item.sourceType == .fileImage) return;
+    final canViewAllMedia = _canViewAllMedia;
     showMenu(
       context: context,
       position: PageUtils.menuPosition(details.globalPosition),
@@ -626,22 +583,23 @@ class _GalleryViewerState extends State<GalleryViewer>
         PopupMenuItem(
           height: 42,
           onTap: () => Utils.copyText(item.url),
-          child: const Text('复制链接', style: TextStyle(fontSize: 14)),
-        ),
-        PopupMenuItem(
-          height: 42,
-          onTap: () => ImageUtils.copyImg(item.url),
-          child: const Text('复制图片', style: TextStyle(fontSize: 14)),
+          child: const Text('澶嶅埗閾炬帴', style: TextStyle(fontSize: 14)),
         ),
         PopupMenuItem(
           height: 42,
           onTap: () => ImageUtils.downloadImg([item.url]),
-          child: const Text('保存图片', style: TextStyle(fontSize: 14)),
+          child: const Text('淇濆瓨鍥剧墖', style: TextStyle(fontSize: 14)),
         ),
+        if (canViewAllMedia)
+          PopupMenuItem(
+            height: 42,
+            onTap: _viewAllMedia,
+            child: const Text('鏌ョ湅鎵€鏈夊浘鐗?, style: TextStyle(fontSize: 14)),
+          ),
         PopupMenuItem(
           height: 42,
           onTap: () => PageUtils.launchURL(item.url),
-          child: const Text('网页打开', style: TextStyle(fontSize: 14)),
+          child: const Text('缃戦〉鎵撳紑', style: TextStyle(fontSize: 14)),
         ),
         if (item.sourceType == SourceType.livePhoto)
           PopupMenuItem(
@@ -652,7 +610,7 @@ class _GalleryViewerState extends State<GalleryViewer>
               width: item.width!,
               height: item.height!,
             ),
-            child: const Text('保存视频', style: TextStyle(fontSize: 14)),
+            child: const Text('淇濆瓨瑙嗛', style: TextStyle(fontSize: 14)),
           ),
       ],
     );
@@ -664,9 +622,9 @@ class _GalleryViewerState extends State<GalleryViewer>
     ImageChunkEvent? loadingProgress,
   ) {
     return Stack(
-      fit: .expand,
-      alignment: .center,
-      clipBehavior: .none,
+      fit: StackFit.expand,
+      alignment: Alignment.center,
+      clipBehavior: Clip.none,
       children: [
         child,
         if (loadingProgress != null &&
@@ -685,3 +643,4 @@ class _GalleryViewerState extends State<GalleryViewer>
     );
   }
 }
+

--- a/lib/common/widgets/image_viewer/gallery_viewer.dart
+++ b/lib/common/widgets/image_viewer/gallery_viewer.dart
@@ -27,7 +27,6 @@ import 'package:PiliPlus/common/widgets/image_viewer/viewer.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart';
 import 'package:PiliPlus/main.dart' show tmpPadding;
 import 'package:PiliPlus/models/common/image_preview_type.dart';
-import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/utils/device_utils.dart';
 import 'package:PiliPlus/utils/extension/num_ext.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
@@ -41,7 +40,8 @@ import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:easy_debounce/easy_throttle.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide Image, PageView;
-import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:flutter/services.dart'
+    show HapticFeedback, SystemChrome, SystemUiOverlay;
 import 'package:get/get.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -96,6 +96,7 @@ class _GalleryViewerState extends State<GalleryViewer>
   double dx = 0, dy = 0;
   Offset _offset = Offset.zero;
   bool _dragging = false;
+  late final bool _hideSystemBar;
 
   String _getActualUrl(String url) {
     return _quality != 100 ? ImageUtils.thumbnailUrl(url, _quality) : url.http2https;
@@ -157,21 +158,16 @@ class _GalleryViewerState extends State<GalleryViewer>
     );
   }
 
-  late final bool _hideSystemBar;
-
   void _initHideSystemBar() {
     if (Platform.isAndroid) {
-      if (showSystemBar_) {
-        final size = DeviceUtils.size;
-        _hideSystemBar = !MaxScreenSize.isWindowMode(
-          width: size.width,
-          height: size.height,
-        );
-      } else {
-        _hideSystemBar = false;
-      }
+      final size = DeviceUtils.size;
+      _hideSystemBar = Pref.imageViewerHideSystemBar &&
+          !MaxScreenSize.isWindowMode(
+            width: size.width,
+            height: size.height,
+          );
     } else if (Platform.isIOS) {
-      _hideSystemBar = showSystemBar_;
+      _hideSystemBar = Pref.imageViewerHideSystemBar;
     } else {
       _hideSystemBar = false;
     }
@@ -186,7 +182,7 @@ class _GalleryViewerState extends State<GalleryViewer>
       _initHideSystemBar();
       if (_hideSystemBar) {
         tmpPadding = padding;
-        hideSystemBar()!.whenComplete(
+        SystemChrome.setEnabledSystemUIMode(.immersiveSticky).whenComplete(
           () => WidgetsBinding.instance.addPostFrameCallback((_) => tmpPadding = null),
         );
       }
@@ -267,7 +263,12 @@ class _GalleryViewerState extends State<GalleryViewer>
     }
     Future.delayed(const Duration(milliseconds: 200), _currIndex.close);
     super.dispose();
-    if (_hideSystemBar) showSystemBar();
+    if (_hideSystemBar) {
+      SystemChrome.setEnabledSystemUIMode(
+        Platform.isAndroid && DeviceUtils.sdkInt < 29 ? .manual : .edgeToEdge,
+        overlays: SystemUiOverlay.values,
+      );
+    }
   }
 
   void _onPointerDown(PointerDownEvent event) {

--- a/lib/pages/article/view.dart
+++ b/lib/pages/article/view.dart
@@ -196,6 +196,7 @@ class _ArticlePageState extends CommonDynPageState<ArticlePage> {
                 child: htmlRender(
                   context: context,
                   html: controller.articleData!.content!,
+                  imgList: controller.articleData!.originImageUrls,
                   maxWidth: maxWidth,
                 ),
               );
@@ -206,6 +207,7 @@ class _ArticlePageState extends CommonDynPageState<ArticlePage> {
                   return htmlRender(
                     context: context,
                     element: res.body!.children[index],
+                    imgList: controller.articleData!.originImageUrls,
                     maxWidth: maxWidth,
                   );
                 },
@@ -281,6 +283,9 @@ class _ArticlePageState extends CommonDynPageState<ArticlePage> {
                                   onTap: () => PageUtils.imageView(
                                     quality: 60,
                                     imgList: pics
+                                        .map((e) => SourceModel(url: e.url!))
+                                        .toList(),
+                                    allSources: pics
                                         .map((e) => SourceModel(url: e.url!))
                                         .toList(),
                                     initialPage: index,

--- a/lib/pages/article/widgets/html_render.dart
+++ b/lib/pages/article/widgets/html_render.dart
@@ -51,9 +51,11 @@ Widget htmlRender({
             );
           }
           final width = isEmote ? 22.0 : maxWidth;
+          final allSources = imgList?.map((url) => SourceModel(url: url)).toList();
           return GestureDetector(
             onTap: () => PageUtils.imageView(
               imgList: [SourceModel(url: imgUrl)],
+              allSources: allSources,
               quality: 60,
             ),
             child: fromHero(

--- a/lib/pages/article/widgets/opus_content.dart
+++ b/lib/pages/article/widgets/opus_content.dart
@@ -258,6 +258,15 @@ class OpusContent extends StatelessWidget {
                         ),
                       )
                       .toList(),
+                  allPicArr: images
+                      .map(
+                        (e) => ImageModel(
+                          width: e.width,
+                          height: e.height,
+                          url: e.url,
+                        ),
+                      )
+                      .toList(),
                 );
               }
             case 3 when (element.line?.pic != null):

--- a/lib/pages/article/widgets/opus_content.dart
+++ b/lib/pages/article/widgets/opus_content.dart
@@ -242,6 +242,7 @@ class OpusContent extends StatelessWidget {
                 return GestureDetector(
                   onTap: () => PageUtils.imageView(
                     imgList: images,
+                    allSources: images,
                     initialPage: images.indexWhere((e) => e.url == pic.url),
                     quality: 60,
                   ),

--- a/lib/pages/article/widgets/opus_content.dart
+++ b/lib/pages/article/widgets/opus_content.dart
@@ -248,6 +248,7 @@ class OpusContent extends StatelessWidget {
                   child: child,
                 );
               } else {
+                final images = this.images();
                 return ImageGridView(
                   picArr: element.pic!.pics!
                       .map(

--- a/lib/pages/dynamics/widgets/content_panel.dart
+++ b/lib/pages/dynamics/widgets/content_panel.dart
@@ -98,6 +98,16 @@ Widget content(
                     height: item.height,
                     url: item.url ?? '',
                     liveUrl: item.liveUrl,
+                    ),
+                  )
+                  .toList(),
+            allPicArr: pics
+                .map(
+                  (item) => ImageModel(
+                    width: item.width,
+                    height: item.height,
+                    url: item.url ?? '',
+                    liveUrl: item.liveUrl,
                   ),
                 )
                 .toList(),

--- a/lib/pages/dynamics/widgets/rich_node_panel.dart
+++ b/lib/pages/dynamics/widgets/rich_node_panel.dart
@@ -274,6 +274,17 @@ TextSpan? richNode(
                             ),
                           )
                           .toList(),
+                      allPicArr: i.dynPic?.isNotEmpty == true
+                          ? i.dynPic!
+                              .map(
+                                (item) => ImageModel(
+                                  url: item.src ?? '',
+                                  width: item.width,
+                                  height: item.height,
+                                ),
+                              )
+                              .toList()
+                          : null,
                     ),
                   ),
                 );

--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -473,6 +473,12 @@ List<SettingsModel> get extraSettings => [
     defaultVal: false,
     onChanged: (value) => ImageGridView.enableImgMenu = value,
   ),
+  const SwitchModel(
+    title: '图片浏览器隐藏系统导航栏',
+    leading: Icon(Icons.navigation_outlined),
+    setKey: SettingBoxKey.imageViewerHideSystemBar,
+    defaultVal: true,
+  ),
   SwitchModel(
     setKey: SettingBoxKey.feedBackEnable,
     onChanged: (value) {

--- a/lib/pages/video/reply/controller.dart
+++ b/lib/pages/video/reply/controller.dart
@@ -1,3 +1,5 @@
+import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart'
+    show ImageModel;
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
     show MainListReply, ReplyInfo;
 import 'package:PiliPlus/grpc/reply.dart';
@@ -5,34 +7,29 @@ import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/pages/common/reply_controller.dart';
 import 'package:PiliPlus/pages/video/controller.dart';
-import 'package:PiliPlus/services/logger.dart';
+import 'package:PiliPlus/pages/video/reply/vote/reply_vote_mixin.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:get/get.dart';
 
-class VideoReplyController extends ReplyController<MainListReply> {
+class VideoReplyController extends ReplyController<MainListReply>
+    with ReplyVoteMixin {
   VideoReplyController({
     required this.aid,
     required this.videoType,
     required this.heroTag,
   });
+
   int aid;
   final VideoType videoType;
   late final isPugv = videoType == VideoType.pugv;
-
   final String heroTag;
   late final videoCtr = Get.find<VideoDetailController>(tag: heroTag);
-
-  // 是否正在进入应用内小窗
-  bool isEnteringPip = false;
 
   @override
   dynamic get sourceId => IdUtils.av2bv(aid);
 
   @override
-  List<ReplyInfo>? getDataList(MainListReply response) {
-    return response.replies;
-  }
+  List<ReplyInfo>? getDataList(MainListReply response) => response.replies;
 
   @override
   Future<LoadingState<MainListReply>> customGetData() => ReplyGrpc.mainList(
@@ -43,16 +40,31 @@ class VideoReplyController extends ReplyController<MainListReply> {
     offset: paginationReply?.nextOffset,
   );
 
-  @override
-  void onClose() {
-    if (kDebugMode) {
-      print(
-        '[PiliNara] VideoReplyController onClose called, isEnteringPip: $isEnteringPip',
-      );
+  List<ImageModel> get allImageModels {
+    final replies = loadingState.value.dataOrNull;
+    if (replies == null || replies.isEmpty) return const [];
+
+    final images = <ImageModel>[];
+    void collect(List<ReplyInfo> items) {
+      for (final reply in items) {
+        if (reply.content.pictures.isNotEmpty) {
+          images.addAll(
+            reply.content.pictures.map(
+              (item) => ImageModel(
+                width: item.imgWidth,
+                height: item.imgHeight,
+                url: item.imgSrc,
+              ),
+            ),
+          );
+        }
+        if (reply.replies.isNotEmpty) {
+          collect(reply.replies);
+        }
+      }
     }
-    if (isEnteringPip) {
-      return;
-    }
-    super.onClose();
+
+    collect(replies);
+    return images;
   }
 }

--- a/lib/pages/video/reply/controller.dart
+++ b/lib/pages/video/reply/controller.dart
@@ -22,6 +22,7 @@ class VideoReplyController extends ReplyController<MainListReply>
   int aid;
   final VideoType videoType;
   late final isPugv = videoType == VideoType.pugv;
+  bool isEnteringPip = false;
   final String heroTag;
   late final videoCtr = Get.find<VideoDetailController>(tag: heroTag);
 

--- a/lib/pages/video/reply/vote/reply_vote_mixin.dart
+++ b/lib/pages/video/reply/vote/reply_vote_mixin.dart
@@ -1,0 +1,19 @@
+import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
+    show MainListReply, VoteCard, ReplyInfo;
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/pages/common/common_list_controller.dart';
+
+mixin ReplyVoteMixin on CommonListController<MainListReply, ReplyInfo> {
+  VoteCard? voteCard;
+
+  @override
+  bool customHandleResponse(bool isRefresh, Success<MainListReply> response) {
+    if (isRefresh) {
+      final res = response.response;
+      if (res.hasVoteCard()) {
+        voteCard = res.voteCard;
+      }
+    }
+    return super.customHandleResponse(isRefresh, response);
+  }
+}

--- a/lib/pages/video/reply/vote/reply_vote_mixin.dart
+++ b/lib/pages/video/reply/vote/reply_vote_mixin.dart
@@ -14,6 +14,9 @@ mixin ReplyVoteMixin on CommonListController<MainListReply, ReplyInfo> {
         voteCard = res.voteCard;
       }
     }
-    return super.customHandleResponse(isRefresh, response);
+    return super.customHandleResponse(
+      isRefresh,
+      response as Success<MainListReply>,
+    );
   }
 }

--- a/lib/pages/video/reply/vote/reply_vote_mixin.dart
+++ b/lib/pages/video/reply/vote/reply_vote_mixin.dart
@@ -7,9 +7,9 @@ mixin ReplyVoteMixin on CommonListController<MainListReply, ReplyInfo> {
   VoteCard? voteCard;
 
   @override
-  bool customHandleResponse(bool isRefresh, Success<MainListReply> response) {
+  bool customHandleResponse(bool isRefresh, Success response) {
     if (isRefresh) {
-      final res = response.response;
+      final res = response.response as MainListReply;
       if (res.hasVoteCard()) {
         voteCard = res.voteCard;
       }

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -371,7 +371,7 @@ class ReplyItemGrpc extends StatelessWidget {
                     ),
                   )
                   .toList(),
-              allPicArr: _resolvedAllPicArr,
+              allPicArrGetter: _resolvedAllPicArr,
               onViewImage: onViewImage,
             ),
           ),

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -371,7 +371,7 @@ class ReplyItemGrpc extends StatelessWidget {
                     ),
                   )
                   .toList(),
-              allPicArrGetter: _resolvedAllPicArr,
+              allPicArrGetter: () => _resolvedAllPicArr,
               onViewImage: onViewImage,
             ),
           ),

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -26,6 +26,7 @@ import 'package:PiliPlus/pages/member/widget/medal_widget.dart';
 import 'package:PiliPlus/pages/save_panel/view.dart';
 import 'package:PiliPlus/pages/audio/controller.dart';
 import 'package:PiliPlus/pages/video/controller.dart';
+import 'package:PiliPlus/pages/video/reply/controller.dart';
 import 'package:PiliPlus/pages/video/reply/widgets/zan_grpc.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/app_scheme.dart';
@@ -68,6 +69,7 @@ class ReplyItemGrpc extends StatelessWidget {
     this.showDialogue,
     this.getTag,
     this.onViewImage,
+    this.allPicArr,
     this.onCheckReply,
     this.onToggleTop,
     this.jumpToDialogue,
@@ -82,9 +84,22 @@ class ReplyItemGrpc extends StatelessWidget {
   final VoidCallback? showDialogue;
   final Function? getTag;
   final VoidCallback? onViewImage;
+  final List<ImageModel>? allPicArr;
   final ValueChanged<ReplyInfo>? onCheckReply;
   final ValueChanged<ReplyInfo>? onToggleTop;
   final VoidCallback? jumpToDialogue;
+
+  List<ImageModel>? get _resolvedAllPicArr {
+    if (allPicArr != null) {
+      return allPicArr;
+    }
+    try {
+      final tag = getTag?.call() ?? Get.arguments['heroTag'];
+      return Get.find<VideoReplyController>(tag: tag).allImageModels;
+    } catch (_) {
+      return null;
+    }
+  }
 
   static final _voteRegExp = RegExp(r"^\{vote:\d+?\}$");
   static final _timeRegExp = RegExp(r'^(?:\d+[:：])?\d+[:：]\d+$');
@@ -356,6 +371,7 @@ class ReplyItemGrpc extends StatelessWidget {
                     ),
                   )
                   .toList(),
+              allPicArr: _resolvedAllPicArr,
               onViewImage: onViewImage,
             ),
           ),

--- a/lib/utils/page_utils.dart
+++ b/lib/utils/page_utils.dart
@@ -45,6 +45,7 @@ abstract final class PageUtils {
   static Future<void> imageView({
     int initialPage = 0,
     required List<SourceModel> imgList,
+    List<SourceModel>? allSources,
     int? quality,
     ValueChanged<int>? onPageChanged,
     String tag = '',
@@ -53,6 +54,7 @@ abstract final class PageUtils {
       HeroDialogRoute(
         pageBuilder: (context, animation, secondaryAnimation) => GalleryViewer(
           sources: imgList,
+          allSources: allSources,
           initIndex: initialPage,
           quality: quality ?? GlobalData().imgQuality,
           onPageChanged: onPageChanged,
@@ -412,14 +414,18 @@ abstract final class PageUtils {
   static void onHorizontalPreviewState(
     ScaffoldState state,
     List<SourceModel> imgList,
-    int index,
-  ) {
+    int index, {
+    List<SourceModel>? allSources,
+    String tag = '',
+  }) {
     state.showBottomSheet(
       constraints: const BoxConstraints(),
       (context) => GalleryViewer(
         sources: imgList,
+        allSources: allSources,
         initIndex: index,
         quality: GlobalData().imgQuality,
+        tag: tag,
       ),
       enableDrag: false,
       elevation: 0.0,

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -175,6 +175,7 @@ abstract final class SettingBoxKey {
       downloadPath = 'downloadPath',
       followOrderType = 'followOrderType',
       enableImgMenu = 'enableImgMenu',
+      imageViewerHideSystemBar = 'imageViewerHideSystemBar',
       showDynDispute = 'showDynDispute',
       touchSlopH = 'touchSlopH',
       floatingNavBar = 'floatingNavBar',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -1465,6 +1465,9 @@ abstract final class Pref {
   static bool get enableImgMenu =>
       _setting.get(SettingBoxKey.enableImgMenu, defaultValue: false);
 
+  static bool get imageViewerHideSystemBar =>
+      _setting.get(SettingBoxKey.imageViewerHideSystemBar, defaultValue: true);
+
   static bool get showDynDispute =>
       _setting.get(SettingBoxKey.showDynDispute, defaultValue: false);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1551,15 +1551,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
-  screen_brightness_android:
-    dependency: "direct overridden"
-    description:
-      path: screen_brightness_android
-      ref: main
-      resolved-ref: "239b9e4595f257184c8afcaf21167f8667ba367d"
-      url: "https://github.com/bggRGjQaUbCoE/screen_brightness.git"
-    source: git
-    version: "2.1.5"
   screen_brightness_ios:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -151,6 +151,7 @@ dependencies:
   protobuf: ^6.0.0
   re_highlight: ^0.0.3
   saver_gallery: ^5.0.2
+  screen_brightness: ^2.1.11
   screen_brightness_platform_interface: ^2.1.0
   screen_retriever: ^0.2.0
   share_plus: ^13.1.0
@@ -228,11 +229,6 @@ dependency_overrides:
       url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit_video
       ref: version_1.2.5
-  screen_brightness_android:
-    git:
-      url: https://github.com/bggRGjQaUbCoE/screen_brightness.git
-      path: screen_brightness_android
-      ref: main
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
本次改动将原先的单图连续浏览调整为“图片总览 + 单图详情”的两层结构，并修复相关交互问题。

### 功能

- 评论区图片长按菜单新增“查看所有图片”
- 点击后进入独立的“图片总览”页，网格展示评论区图片
- 总览页支持多选、全选/取消全选、批量下载
