### PR TITLE
fix(ui/ux): 在打开稍后再看时预加载未看完视频数量

### DIFF
--- a/lib/pages/later/child_view.dart
+++ b/lib/pages/later/child_view.dart
@@ -33,8 +33,8 @@ class _LaterViewChildPageState extends State<LaterViewChildPage>
   @override
   void initState() {
     super.initState();
-    _laterController = Get.put(
-      LaterController(widget.laterViewType),
+    _laterController = Get.putOrFind(
+      () => LaterController(widget.laterViewType),
       tag: widget.laterViewType.type.toString(),
     );
   }

--- a/lib/pages/later/view.dart
+++ b/lib/pages/later/view.dart
@@ -51,6 +51,13 @@ class _LaterPageState extends State<LaterPage>
       length: LaterViewType.values.length,
       vsync: this,
     )..addListener(listener);
+    
+    for (final type in LaterViewType.values) {
+      Get.put(
+        LaterController(type),
+        tag: type.type.toString(),
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
## 问题

在刚打开稍后再看时，未看完视频的计数不会显示，如图一；必须要点“未看完”一次之后才能看到计数，如图二：

| <img width="1206" height="2622" alt="Weixin Image_20260701204122_51_114" src="https://github.com/user-attachments/assets/242e69a8-3b60-4453-974e-4f3439ab7d4d" /> | <img width="1206" height="2622" alt="Weixin Image_20260701204123_52_114" src="https://github.com/user-attachments/assets/cc8a045b-0924-44af-b28e-bc112fdb4585" /> |
| - | - |

## 效果

已在iOS下测试，在刚打开稍后再看时，可以同时看到全部和未看完视频的计数，即图二效果。

测试下来是上游的问题，本来是想发Issue的，但是并未启用，然后[在上游的PR#2436](https://github.com/bggRGjQaUbCoE/PiliPlus/pull/2436)也直接被无评论关闭了，不知道是什么原因，dom佬好神秘。故将fix发到这里，希望能够提前合并，或是麻烦大佬指出问题？谢谢！