### PR TITLE
feat: 新增 Windows 端 Z/X/C 快捷键快速调节播放倍速（#211）

### DIFF
--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -98,16 +98,22 @@ class PlayerFocus extends StatelessWidget {
       ..showKeyboardSpeedToast(newSpeed);
   }
 
-  /// Z/C 长按：按下时步进一次并启动定时器（每 100ms 步进），松开取消
+  /// Z/C 长按：按下步进一次，300ms 延迟后持续步进（每 100ms），松开取消
   void _updateSpeed(KeyEvent event, {required bool isIncrease}) {
     if (event is KeyDownEvent) {
       if (hasPlayer) {
         _changeSpeed(isIncrease: isIncrease);
+        // 300ms 防误触阈值，过后才开始连续步进
         plPlayerController
           ..longPressTimer?.cancel()
-          ..longPressTimer = Timer.periodic(
-            const Duration(milliseconds: 100),
-            (_) => _changeSpeed(isIncrease: isIncrease),
+          ..longPressTimer = Timer(
+            const Duration(milliseconds: 300),
+            () => plPlayerController
+              ..cancelLongPressTimer()
+              ..longPressTimer = Timer.periodic(
+                const Duration(milliseconds: 100),
+                (_) => _changeSpeed(isIncrease: isIncrease),
+              ),
           );
       }
     } else if (event is KeyUpEvent) {
@@ -153,6 +159,22 @@ class PlayerFocus extends StatelessWidget {
     if (isKeyZ || key == LogicalKeyboardKey.keyC) {
       if (!plPlayerController.isLive && hasPlayer) {
         _updateSpeed(event, isIncrease: key == LogicalKeyboardKey.keyC);
+      }
+      return true;
+    }
+
+    // X：切换倍速。当前速度≠1.0 切到 1.0，当前=1.0 恢复上次非 1.0 速度
+    if (key == LogicalKeyboardKey.keyX) {
+      if (event is KeyDownEvent && !plPlayerController.isLive && hasPlayer) {
+        final currentTenths = (plPlayerController.playbackSpeed * 10).round();
+        final lastTenths = (plPlayerController.lastPlaybackSpeed * 10).round();
+        final targetTenths = currentTenths != 10
+            ? 10
+            : (lastTenths != 10 ? lastTenths : 20);
+        final target = targetTenths / 10.0;
+        plPlayerController
+          ..setPlaybackSpeed(target)
+          ..showKeyboardSpeedToast(target);
       }
       return true;
     }

--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -90,15 +90,15 @@ class PlayerFocus extends StatelessWidget {
   void _changeSpeed({required bool isIncrease}) {
     final tenths = (plPlayerController.playbackSpeed * 10).round();
     final newTenths = isIncrease
-        ? (tenths + 1).clamp(1, 160)
-        : (tenths - 1).clamp(1, 160);
+        ? (tenths + 1).clamp(1, 60)
+        : (tenths - 1).clamp(1, 60);
     final newSpeed = newTenths / 10.0;
     plPlayerController
       ..setPlaybackSpeed(newSpeed)
       ..showKeyboardSpeedToast(newSpeed);
   }
 
-  /// Z/C 长按：按下步进一次，300ms 延迟后持续步进（每 100ms），松开取消
+  /// X/C 长按：按下步进一次，300ms 延迟后持续步进（每 100ms），松开取消
   void _updateSpeed(KeyEvent event, {required bool isIncrease}) {
     if (event is KeyDownEvent) {
       if (hasPlayer) {
@@ -154,27 +154,20 @@ class PlayerFocus extends StatelessWidget {
       return true;
     }
 
-    // Z/C 倍速快捷键（Z 减速、C 加速），支持长按持续调节（每 100ms 步进 0.1x）
-    final isKeyZ = key == LogicalKeyboardKey.keyZ;
-    if (isKeyZ || key == LogicalKeyboardKey.keyC) {
-      if (!plPlayerController.isLive && hasPlayer) {
-        _updateSpeed(event, isIncrease: key == LogicalKeyboardKey.keyC);
+    // Z：恢复 1.0x 倍速
+    if (key == LogicalKeyboardKey.keyZ) {
+      if (event is KeyDownEvent && !plPlayerController.isLive && hasPlayer) {
+        plPlayerController
+          ..setPlaybackSpeed(1.0)
+          ..showKeyboardSpeedToast(1.0);
       }
       return true;
     }
 
-    // X：切换倍速。当前速度≠1.0 切到 1.0，当前=1.0 恢复上次非 1.0 速度
-    if (key == LogicalKeyboardKey.keyX) {
-      if (event is KeyDownEvent && !plPlayerController.isLive && hasPlayer) {
-        final currentTenths = (plPlayerController.playbackSpeed * 10).round();
-        final lastTenths = (plPlayerController.lastPlaybackSpeed * 10).round();
-        final targetTenths = currentTenths != 10
-            ? 10
-            : (lastTenths != 10 ? lastTenths : 20);
-        final target = targetTenths / 10.0;
-        plPlayerController
-          ..setPlaybackSpeed(target)
-          ..showKeyboardSpeedToast(target);
+    // X/C 倍速加减（X 减速、C 加速），支持长按持续调节（每 100ms 步进 0.1x）
+    if (key == LogicalKeyboardKey.keyX || key == LogicalKeyboardKey.keyC) {
+      if (!plPlayerController.isLive && hasPlayer) {
+        _updateSpeed(event, isIncrease: key == LogicalKeyboardKey.keyC);
       }
       return true;
     }

--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -172,24 +172,27 @@ class PlayerFocus extends StatelessWidget {
               ? 10
               : (lastTenths != 10 ? lastTenths : 20);  // 初始状态无历史切到 2.0
           final target = targetTenths / 10.0;
-          plPlayerController.setPlaybackSpeed(target);
-          SmartDialog.showToast('${target.toStringAsFixed(1)}x播放');
+          plPlayerController
+            ..setPlaybackSpeed(target)
+            ..showKeyboardSpeedToast(target);
           return true;
         }
         if (key == LogicalKeyboardKey.keyX) {
           // X：减速 0.1x，下限 0.1x
           final tenths = (plPlayerController.playbackSpeed * 10).round();
-          final newSpeed = (tenths - 1).clamp(1, 40) / 10.0;
-          plPlayerController.setPlaybackSpeed(newSpeed);
-          SmartDialog.showToast('${newSpeed.toStringAsFixed(1)}x播放');
+          final newSpeed = (tenths - 1).clamp(1, 160) / 10.0;
+          plPlayerController
+            ..setPlaybackSpeed(newSpeed)
+            ..showKeyboardSpeedToast(newSpeed);
           return true;
         }
         if (key == LogicalKeyboardKey.keyC) {
-          // C：加速 0.1x，上限 4.0x
+          // C：加速 0.1x，上限 16.0x（参考 PotPlayer / Global Speed 默认上限）
           final tenths = (plPlayerController.playbackSpeed * 10).round();
-          final newSpeed = (tenths + 1).clamp(1, 40) / 10.0;
-          plPlayerController.setPlaybackSpeed(newSpeed);
-          SmartDialog.showToast('${newSpeed.toStringAsFixed(1)}x播放');
+          final newSpeed = (tenths + 1).clamp(1, 160) / 10.0;
+          plPlayerController
+            ..setPlaybackSpeed(newSpeed)
+            ..showKeyboardSpeedToast(newSpeed);
           return true;
         }
       }

--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -86,6 +86,35 @@ class PlayerFocus extends StatelessWidget {
     }
   }
 
+  /// 单次倍速步进（0.1x），使用整数十份位运算避免浮点精度累积误差
+  void _changeSpeed({required bool isIncrease}) {
+    final tenths = (plPlayerController.playbackSpeed * 10).round();
+    final newTenths = isIncrease
+        ? (tenths + 1).clamp(1, 160)
+        : (tenths - 1).clamp(1, 160);
+    final newSpeed = newTenths / 10.0;
+    plPlayerController
+      ..setPlaybackSpeed(newSpeed)
+      ..showKeyboardSpeedToast(newSpeed);
+  }
+
+  /// Z/C 长按：按下时步进一次并启动定时器（每 100ms 步进），松开取消
+  void _updateSpeed(KeyEvent event, {required bool isIncrease}) {
+    if (event is KeyDownEvent) {
+      if (hasPlayer) {
+        _changeSpeed(isIncrease: isIncrease);
+        plPlayerController
+          ..longPressTimer?.cancel()
+          ..longPressTimer = Timer.periodic(
+            const Duration(milliseconds: 100),
+            (_) => _changeSpeed(isIncrease: isIncrease),
+          );
+      }
+    } else if (event is KeyUpEvent) {
+      plPlayerController.cancelLongPressTimer();
+    }
+  }
+
   bool _handleKey(KeyEvent event) {
     final key = event.logicalKey;
 
@@ -116,6 +145,15 @@ class PlayerFocus extends StatelessWidget {
     final isArrowUp = key == LogicalKeyboardKey.arrowUp;
     if (isArrowUp || key == LogicalKeyboardKey.arrowDown) {
       _updateVolume(event, isIncrease: isArrowUp);
+      return true;
+    }
+
+    // Z/C 倍速快捷键（Z 减速、C 加速），支持长按持续调节（每 100ms 步进 0.1x）
+    final isKeyZ = key == LogicalKeyboardKey.keyZ;
+    if (isKeyZ || key == LogicalKeyboardKey.keyC) {
+      if (!plPlayerController.isLive && hasPlayer) {
+        _updateSpeed(event, isIncrease: key == LogicalKeyboardKey.keyC);
+      }
       return true;
     }
 
@@ -159,42 +197,6 @@ class PlayerFocus extends StatelessWidget {
           SmartDialog.showToast('${speed}x播放');
         }
         return true;
-      }
-
-      // Z/X/C 快捷键调节播放倍速（步进 0.1x，实现 #211）
-      if (!plPlayerController.isLive && hasPlayer) {
-        if (key == LogicalKeyboardKey.keyZ) {
-          // Z：切换倍速。当前速度≠1.0 时切到 1.0，当前=1.0 时恢复上次非 1.0 速度
-          // 使用整数十份位运算避免浮点精度累积误差
-          final currentTenths = (plPlayerController.playbackSpeed * 10).round();
-          final lastTenths = (plPlayerController.lastPlaybackSpeed * 10).round();
-          final targetTenths = currentTenths != 10
-              ? 10
-              : (lastTenths != 10 ? lastTenths : 20);  // 初始状态无历史切到 2.0
-          final target = targetTenths / 10.0;
-          plPlayerController
-            ..setPlaybackSpeed(target)
-            ..showKeyboardSpeedToast(target);
-          return true;
-        }
-        if (key == LogicalKeyboardKey.keyX) {
-          // X：减速 0.1x，下限 0.1x
-          final tenths = (plPlayerController.playbackSpeed * 10).round();
-          final newSpeed = (tenths - 1).clamp(1, 160) / 10.0;
-          plPlayerController
-            ..setPlaybackSpeed(newSpeed)
-            ..showKeyboardSpeedToast(newSpeed);
-          return true;
-        }
-        if (key == LogicalKeyboardKey.keyC) {
-          // C：加速 0.1x，上限 16.0x（参考 PotPlayer / Global Speed 默认上限）
-          final tenths = (plPlayerController.playbackSpeed * 10).round();
-          final newSpeed = (tenths + 1).clamp(1, 160) / 10.0;
-          plPlayerController
-            ..setPlaybackSpeed(newSpeed)
-            ..showKeyboardSpeedToast(newSpeed);
-          return true;
-        }
       }
 
       switch (key) {

--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -161,6 +161,39 @@ class PlayerFocus extends StatelessWidget {
         return true;
       }
 
+      // Z/X/C 快捷键调节播放倍速（步进 0.1x，实现 #211）
+      if (!plPlayerController.isLive && hasPlayer) {
+        if (key == LogicalKeyboardKey.keyZ) {
+          // Z：切换倍速。当前速度≠1.0 时切到 1.0，当前=1.0 时恢复上次非 1.0 速度
+          // 使用整数十份位运算避免浮点精度累积误差
+          final currentTenths = (plPlayerController.playbackSpeed * 10).round();
+          final lastTenths = (plPlayerController.lastPlaybackSpeed * 10).round();
+          final targetTenths = currentTenths != 10
+              ? 10
+              : (lastTenths != 10 ? lastTenths : 20);  // 初始状态无历史切到 2.0
+          final target = targetTenths / 10.0;
+          plPlayerController.setPlaybackSpeed(target);
+          SmartDialog.showToast('${target.toStringAsFixed(1)}x播放');
+          return true;
+        }
+        if (key == LogicalKeyboardKey.keyX) {
+          // X：减速 0.1x，下限 0.1x
+          final tenths = (plPlayerController.playbackSpeed * 10).round();
+          final newSpeed = (tenths - 1).clamp(1, 40) / 10.0;
+          plPlayerController.setPlaybackSpeed(newSpeed);
+          SmartDialog.showToast('${newSpeed.toStringAsFixed(1)}x播放');
+          return true;
+        }
+        if (key == LogicalKeyboardKey.keyC) {
+          // C：加速 0.1x，上限 4.0x
+          final tenths = (plPlayerController.playbackSpeed * 10).round();
+          final newSpeed = (tenths + 1).clamp(1, 40) / 10.0;
+          plPlayerController.setPlaybackSpeed(newSpeed);
+          SmartDialog.showToast('${newSpeed.toStringAsFixed(1)}x播放');
+          return true;
+        }
+      }
+
       switch (key) {
         case LogicalKeyboardKey.space:
           if (plPlayerController.isLive || canPlay!()) {

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1885,6 +1885,7 @@ class PlPlayerController with BlockConfigMixin {
       AndroidHelper$ToDart.onUserLeaveHint = null;
     }
     _timer?.cancel();
+    _keyboardSpeedTimer?.cancel();
     // _position.close();
     // _playerEventSubs?.cancel();
     // _sliderPosition.close();

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -107,6 +107,17 @@ class PlPlayerController with BlockConfigMixin {
   final RxDouble _playbackSpeed = Pref.playSpeedDefault.obs;
   late final RxDouble _longPressSpeed = Pref.longPressSpeedDefault.obs;
 
+  /// 键盘快捷键倍速提示（Z/X/C），显示于播放器内中下部
+  final RxDouble keyboardSpeedToast = RxDouble(0.0);
+  Timer? _keyboardSpeedTimer;
+  void showKeyboardSpeedToast(double speed) {
+    keyboardSpeedToast.value = speed;
+    _keyboardSpeedTimer?.cancel();
+    _keyboardSpeedTimer = Timer(const Duration(seconds: 1), () {
+      keyboardSpeedToast.value = 0.0;
+    });
+  }
+
   final RxDouble volume = RxDouble(
     PlatformUtils.isDesktop ? Pref.desktopVolume : 1.0,
   );

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -1571,6 +1571,35 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             ),
           ),
 
+        /// 键盘快捷键（Z/X/C）倍速提示，显示于播放器内中下部
+        Obx(
+          () => AnimatedOpacity(
+            curve: Curves.easeInOut,
+            opacity: plPlayerController.keyboardSpeedToast.value > 0 ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 150),
+            child: Align(
+              alignment: const Alignment(0, 0.65),
+              child: IgnorePointer(
+                ignoring: true,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
+                  ),
+                  decoration: const BoxDecoration(
+                    color: Color(0x88000000),
+                    borderRadius: BorderRadius.all(Radius.circular(16)),
+                  ),
+                  child: Text(
+                    '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x播放',
+                    style: const TextStyle(color: Colors.white, fontSize: 13),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+
         /// 时间进度 toast
         if (!isLive)
           Positioned.fill(

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -1591,7 +1591,9 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                     borderRadius: BorderRadius.all(Radius.circular(16)),
                   ),
                   child: Text(
-                    '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x播放',
+                    plPlayerController.keyboardSpeedToast.value > 0
+                        ? '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x播放'
+                        : '',
                     style: const TextStyle(color: Colors.white, fontSize: 13),
                   ),
                 ),

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -1581,20 +1581,20 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
               alignment: const Alignment(0, 0.65),
               child: IgnorePointer(
                 ignoring: true,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 10,
-                    vertical: 6,
-                  ),
-                  decoration: const BoxDecoration(
-                    color: Color(0x88000000),
-                    borderRadius: BorderRadius.all(Radius.circular(16)),
-                  ),
-                  child: Text(
-                    plPlayerController.keyboardSpeedToast.value > 0
-                        ? '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x播放'
-                        : '',
-                    style: const TextStyle(color: Colors.white, fontSize: 13),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 8,
+                    ),
+                    decoration: const BoxDecoration(
+                      color: Color(0x88000000),
+                      borderRadius: BorderRadius.all(Radius.circular(16)),
+                    ),
+                    child: Text(
+                      plPlayerController.keyboardSpeedToast.value > 0
+                          ? '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x'
+                          : '',
+                      style: const TextStyle(color: Colors.white, fontSize: 20),
                   ),
                 ),
               ),


### PR DESCRIPTION
## 新增 Windows 端 Z/X/C 快捷键快速调整视频播放倍速

**关闭：#211**

### 快捷键映射

| 按键 | 功能 |
|------|------|
| **Z** | 恢复 1.0x 倍速 |
| **X** | 减速，每按一次减少 0.1x，长按 300ms 后连续减速（每 100ms 步进一次） |
| **C** | 加速，每按一次增加 0.1x，长按 300ms 后连续加速（每 100ms 步进一次） |

- 速度范围：0.1x ~ 6.0x（实测 8x 及以上音画不同步/无声）
- 直播画面自动禁用
- 受设置中「启用键盘控制」开关控制

### 倍速提示显示

- 倍速信息显示在**播放器画面内部中下部**（而非全局 SmartDialog），避免遮挡其他窗口元素
- 半透明黑底圆角标签，字号 20，显示格式如 `1.5x`
- 操作后 1 秒自动淡出

### 实现细节

- 使用**整数十份位运算**（`tenths = (speed * 10).round()`），从根本上避免浮点数累加产生的精度误差
- X/C 长按持续调节：按下瞬间步进一次，300ms 阈值防误触后启动 `Timer.periodic(100ms)` 连续步进，松开立即停止
- 所有代码仅新增，未修改播放器原有任何逻辑

### 涉及修改

| 文件 | 改动 |
|------|------|
| `lib/pages/video/widgets/player_focus.dart` | 新增 Z/X/C 快捷键处理逻辑 |
| `lib/plugin/pl_player/controller.dart` | 新增 `keyboardSpeedToast` 响应式字段和 `showKeyboardSpeedToast()` 方法，`dispose()` 中清理定时器 |
| `lib/plugin/pl_player/view/view.dart` | 新增播放器内倍速提示叠加层 |