### PR TITLE
Refac/inpip-优化应用内画中画小窗缩放动画、边缘锚定逻辑

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -95,7 +95,7 @@ class VideoDetailPageV extends StatefulWidget {
 
 class _VideoDetailPageVState extends State<VideoDetailPageV>
     with RouteAware, RouteAwareMixin, WidgetsBindingObserver {
-  final heroTag = Get.arguments['heroTag'];
+  late final String heroTag;
 
   late final VideoDetailController videoDetailController;
   late final VideoReplyController _videoReplyController;
@@ -254,6 +254,28 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     final String? targetContextKey = PipOverlayService.contextKeyFromArgs(
       Get.arguments is Map ? Get.arguments as Map : null,
     );
+    // 同视频复用：从推荐流/动态等入口点开 PiP 中正在播放的同一视频
+    // （videoType|bvid|cid|epId|seasonId 完全匹配）时，走与 fromPip
+    // 相同的 controller 恢复路径，避免重新加载。cid 不同则正常加载。
+    final bool isSameVideo =
+        !fromPip &&
+        targetContextKey != null &&
+        targetContextKey == PipOverlayService.savedVideoContextKey;
+    final bool shouldRestoreFromPip = fromPip || isSameVideo;
+    final restoredController =
+        shouldRestoreFromPip && PipOverlayService.isInPipMode
+        ? PipOverlayService.getSavedController<VideoDetailController>()
+        : null;
+    final bool restoringFromPip = restoredController != null;
+
+    // heroTag 是这组 GetX controller 的作用域标识。复用已有 controller
+    // 时必须沿用其原 tag；这里只在页面初始化时决定一次，之后保持不变。
+    heroTag = restoredController?.heroTag ?? Get.arguments['heroTag'];
+    if (restoredController != null && Get.arguments is Map) {
+      // 附属 controller 的 onInit 仍从 Get.arguments 读取 heroTag，需在创建
+      // 它们之前同步为同一作用域，避免主/附属 controller 的 tag 分裂。
+      (Get.arguments as Map)['heroTag'] = heroTag;
+    }
 
     // 如果有直播间 PiP 在运行，关闭它（采用非销毁式，避免干扰视频播放器单例）
     if (LivePipOverlayService.isInPipMode && !fromPip) {
@@ -262,10 +284,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
 
     PlPlayerController.setPlayCallBack(playCallBack);
 
-    // 如果从 PiP 返回，尝试恢复保存的控制器
-    if (fromPip && PipOverlayService.isInPipMode) {
-      final savedController =
-          PipOverlayService.getSavedController<VideoDetailController>();
+    // 如果从 PiP 返回或从外部入口点开同视频，尝试恢复保存的控制器
+    if (shouldRestoreFromPip && PipOverlayService.isInPipMode) {
+      final savedController = restoredController;
       if (savedController != null) {
         // 必须在 stopPip 之前取出所有 additional controllers，
         // 因为 stopPip 会调用 _savedControllers.clear() 清空缓存
@@ -361,7 +382,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       // 注意：_savedReplyControllerFromPip 在 stopPip 之前已提前取出
       final savedReplyController =
           _savedReplyControllerFromPip ??
-          (fromPip
+          (restoringFromPip
               ? PipOverlayService.getAdditionalController<VideoReplyController>(
                   'reply',
                 )
@@ -387,7 +408,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     // 注意：_savedIntroControllerFromPip 在 stopPip 之前已提前取出
     final savedIntroController =
         _savedIntroControllerFromPip ??
-        (fromPip ? PipOverlayService.getAdditionalController('intro') : null);
+        (restoringFromPip
+            ? PipOverlayService.getAdditionalController('intro')
+            : null);
 
     if (videoDetailController.isFileSource) {
       if (savedIntroController != null &&
@@ -428,7 +451,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       Get.put(AiChatController(heroTag: heroTag), tag: heroTag);
     }
 
-    if (fromPip) {
+    if (restoringFromPip) {
       plPlayerController = videoDetailController.plPlayerController;
       final wasPlaying = plPlayerController!.playerStatus.isPlaying;
 

--- a/lib/services/live_pip_overlay_service.dart
+++ b/lib/services/live_pip_overlay_service.dart
@@ -444,14 +444,36 @@ class _LivePipWidgetState extends State<LivePipWidget>
     if ((next - _scale).abs() < 0.05) {
       next = PipWindowMemory.clampScaleContinuous(1.0, screenSize);
     }
+    // 双击档位切换:按缩放前窗口距屏幕四边的距离,选较近的一对边作为锚定,
+    // 缩放后保持该边缘到屏幕边缘的距离不变。
+    // 否则贴右窗口放大→缩小会"跑到左边":放大时钳制把 _left 顶到
+    // screenW-w2(贴右);缩小时 _left=screenW-w2 落在合法区间内不变,
+    // 但右边缘变成 screenW-w2+w3 < screenW,视觉上窗口向左缩。
+    final oldLeft = _left ?? 0.0;
+    final oldTop = _top ?? 0.0;
+    final oldWidth = _width;
+    final oldHeight = _height;
+    final distLeft = oldLeft;
+    final distRight = screenSize.width - oldLeft - oldWidth;
+    final distTop = oldTop;
+    final distBottom = screenSize.height - oldTop - oldHeight;
+
     setState(() {
       _scale = next;
 
-      // 缩放后立即计算并约束位置，防止按钮或部分窗口超出屏幕
-      _left = (_left ?? 0.0)
+      // 水平:距左≤距右则左锚定(_left 不变),否则右锚定(右边缘到屏距离不变)
+      final double newLeft = distLeft <= distRight
+          ? oldLeft
+          : screenSize.width - distRight - _width;
+      // 垂直:距上≤距下则上锚定(_top 不变),否则下锚定(下边缘到屏距离不变)
+      final double newTop = distTop <= distBottom
+          ? oldTop
+          : screenSize.height - distBottom - _height;
+      // 兜底钳制,防极端窗口/旋转后越界
+      _left = newLeft
           .clamp(0.0, max(0.0, screenSize.width - _width))
           .toDouble();
-      _top = (_top ?? 0.0)
+      _top = newTop
           .clamp(0.0, max(0.0, screenSize.height - _height))
           .toDouble();
     });
@@ -538,7 +560,17 @@ class _LivePipWidgetState extends State<LivePipWidget>
               phase == PipPhase.entering || phase == PipPhase.restoring;
           final bool interactive = phase == PipPhase.active && !_isClosing;
 
-          return Positioned(
+          // AnimatedPositioned 与下方 AnimatedContainer 共用相同的
+          // duration/curve 条件:双击档位切换时位置与尺寸同步 250ms 过渡,
+          // 否则右边缘双击放大时"位置先瞬移、尺寸后长大"地抽搐
+          // (左边缘因 _left 钳制后仍为 0 不受影响,故仅右侧显现)。
+          // inTransition(收起/归位)与 _instantResize(捏合/滚轮)期间归零,
+          // 与 AnimatedContainer 行为一致。
+          return AnimatedPositioned(
+            duration: inTransition || _instantResize
+                ? Duration.zero
+                : const Duration(milliseconds: 250),
+            curve: Curves.easeOutCubic,
             left: rect.left,
             top: rect.top,
             child: IgnorePointer(

--- a/lib/services/pip_overlay_service.dart
+++ b/lib/services/pip_overlay_service.dart
@@ -8,9 +8,9 @@ import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/services/logger.dart';
 import 'package:PiliPlus/services/pip_transition_coordinator.dart';
 import 'package:PiliPlus/services/service_locator.dart';
-import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/device_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart'
     show PointerEnterEvent, PointerExitEvent, PointerScrollEvent;
@@ -337,8 +337,7 @@ class PipOverlayService {
       final ctrl = _savedController as VideoDetailController;
       ctrl.isEnteringPip = false;
       ctrl.cancelBlockListener();
-      if (ctrl.isClosed) {
-      }
+      if (ctrl.isClosed) {}
       for (final controller in _savedControllers.values) {
         _setEnteringPipFlag(controller, false);
       }
@@ -604,14 +603,36 @@ class _PipWidgetState extends State<PipWidget>
     if ((next - _scale).abs() < 0.05) {
       next = PipWindowMemory.clampScaleContinuous(1.0, screenSize);
     }
+    // 双击档位切换:按缩放前窗口距屏幕四边的距离,选较近的一对边作为锚定,
+    // 缩放后保持该边缘到屏幕边缘的距离不变。
+    // 否则贴右窗口放大→缩小会"跑到左边":放大时钳制把 _left 顶到
+    // screenW-w2(贴右);缩小时 _left=screenW-w2 落在合法区间内不变,
+    // 但右边缘变成 screenW-w2+w3 < screenW,视觉上窗口向左缩。
+    final oldLeft = _left ?? 0.0;
+    final oldTop = _top ?? 0.0;
+    final oldWidth = _width;
+    final oldHeight = _height;
+    final distLeft = oldLeft;
+    final distRight = screenSize.width - oldLeft - oldWidth;
+    final distTop = oldTop;
+    final distBottom = screenSize.height - oldTop - oldHeight;
+
     setState(() {
       _scale = next;
 
-      // 缩放后立即计算并约束位置，防止按钮或部分窗口超出屏幕
-      _left = (_left ?? 0.0)
+      // 水平:距左≤距右则左锚定(_left 不变),否则右锚定(右边缘到屏距离不变)
+      final double newLeft = distLeft <= distRight
+          ? oldLeft
+          : screenSize.width - distRight - _width;
+      // 垂直:距上≤距下则上锚定(_top 不变),否则下锚定(下边缘到屏距离不变)
+      final double newTop = distTop <= distBottom
+          ? oldTop
+          : screenSize.height - distBottom - _height;
+      // 兜底钳制,防极端窗口/旋转后越界
+      _left = newLeft
           .clamp(0.0, max(0.0, screenSize.width - _width))
           .toDouble();
-      _top = (_top ?? 0.0)
+      _top = newTop
           .clamp(0.0, max(0.0, screenSize.height - _height))
           .toDouble();
     });
@@ -699,7 +720,17 @@ class _PipWidgetState extends State<PipWidget>
               phase == PipPhase.entering || phase == PipPhase.restoring;
           final bool interactive = phase == PipPhase.active && !_isClosing;
 
-          return Positioned(
+          // AnimatedPositioned 与下方 AnimatedContainer 共用相同的
+          // duration/curve 条件:双击档位切换时位置与尺寸同步 250ms 过渡,
+          // 否则右边缘双击放大时"位置先瞬移、尺寸后长大"地抽搐
+          // (左边缘因 _left 钳制后仍为 0 不受影响,故仅右侧显现)。
+          // inTransition(收起/归位)与 _instantResize(捏合/滚轮)期间归零,
+          // 与 AnimatedContainer 行为一致。
+          return AnimatedPositioned(
+            duration: inTransition || _instantResize
+                ? Duration.zero
+                : const Duration(milliseconds: 250),
+            curve: Curves.easeOutCubic,
             left: rect.left,
             top: rect.top,
             child: IgnorePointer(
@@ -765,193 +796,197 @@ class _PipWidgetState extends State<PipWidget>
                     onEnter: _onHoverEnter,
                     onExit: _onHoverExit,
                     child: FadeTransition(
-                  opacity: _closeCtr.drive(Tween(begin: 1.0, end: 0.0)),
-                  child: ScaleTransition(
-                    scale: _closeCtr.drive(
-                      Tween(
-                        begin: 1.0,
-                        end: 0.85,
-                      ).chain(CurveTween(curve: Curves.easeOut)),
-                    ),
-                    child: AnimatedContainer(
-                      // 过渡中矩形逐帧由协调器插值给出;捏合/滚轮中尺寸须与
-                      // 位置同帧生效(见 _instantResize)。两者时长归零,
-                      // 仅双击档位切换保留 250ms 尺寸过渡
-                      duration: inTransition || _instantResize
-                          ? Duration.zero
-                          : const Duration(milliseconds: 250),
-                      curve: Curves.easeOutCubic,
-                      width: rect.width,
-                      height: rect.height,
-                      decoration: BoxDecoration(
-                        color: Colors.black,
-                        borderRadius: BorderRadius.circular(radius),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.5),
-                            blurRadius: 10,
-                            spreadRadius: 2,
-                          ),
-                        ],
-                      ),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(radius),
-                        child: Stack(
-                          children: [
-                            Positioned.fill(
-                              child: AbsorbPointer(
-                                child: widget.videoPlayerBuilder(
-                                  false,
-                                  rect.width,
-                                  rect.height,
-                                ),
-                              ),
-                            ),
-                            if (interactive && _showControls) ...[
-                              Positioned.fill(
-                                child: Container(
-                                  color: Colors.black.withValues(alpha: 0.4),
-                                ),
-                              ),
-                              // 左上角关闭：先播缩小淡出再 stopPip
-                              Positioned(
-                                top: 3,
-                                left: 4,
-                                child: GestureDetector(
-                                  onTap: _beginClose,
-                                  child: const Padding(
-                                    padding: EdgeInsets.all(8.0),
-                                    child: Icon(
-                                      Icons.close,
-                                      color: Colors.white,
-                                      size: 21,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              // 右上角还原：归位动画启动，窗口保持显示飞向页面
-                              Positioned(
-                                top: 3,
-                                right: 4,
-                                child: GestureDetector(
-                                  onTap: () {
-                                    _hideTimer?.cancel();
-                                    widget.onTapToReturn();
-                                  },
-                                  child: const Padding(
-                                    padding: EdgeInsets.all(8.0),
-                                    child: Icon(
-                                      Icons.open_in_full,
-                                      color: Colors.white,
-                                      size: 19,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              // 底部控制栏
-                              Positioned(
-                                left: 0,
-                                right: 0,
-                                bottom: 8,
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceEvenly,
-                                  children: [
-                                    // 后退10秒
-                                    GestureDetector(
-                                      onTap: () {
-                                        _resetHideTimer();
-                                        final controller = PipOverlayService
-                                            .getSavedController<
-                                              VideoDetailController
-                                            >();
-                                        final plController =
-                                            controller?.plPlayerController;
-                                        if (plController != null) {
-                                          final current = Duration(
-                                            seconds:
-                                                plController.position.value,
-                                          );
-                                          plController.seekTo(
-                                            current -
-                                                const Duration(seconds: 10),
-                                          );
-                                        }
-                                      },
-                                      child: const Icon(
-                                        Icons.replay_10,
-                                        color: Colors.white,
-                                        size: 22,
-                                      ),
-                                    ),
-                                    // 播放/暂停
-                                    Obx(() {
-                                      final controller = PipOverlayService
-                                          .getSavedController<
-                                            VideoDetailController
-                                          >();
-                                      final plController =
-                                          controller?.plPlayerController;
-                                      final isPlaying =
-                                          plController?.playerStatus.value ==
-                                          PlayerStatus.playing;
-                                      return GestureDetector(
-                                        onTap: () {
-                                          _resetHideTimer();
-                                          if (isPlaying) {
-                                            plController?.pause();
-                                          } else {
-                                            plController?.play();
-                                          }
-                                        },
-                                        child: Icon(
-                                          isPlaying
-                                              ? Icons.pause
-                                              : Icons.play_arrow,
-                                          color: Colors.white,
-                                          size: 30,
-                                        ),
-                                      );
-                                    }),
-                                    // 前进10秒
-                                    GestureDetector(
-                                      onTap: () {
-                                        _resetHideTimer();
-                                        final controller = PipOverlayService
-                                            .getSavedController<
-                                              VideoDetailController
-                                            >();
-                                        final plController =
-                                            controller?.plPlayerController;
-                                        if (plController != null) {
-                                          final current = Duration(
-                                            seconds:
-                                                plController.position.value,
-                                          );
-                                          plController.seekTo(
-                                            current +
-                                                const Duration(seconds: 10),
-                                          );
-                                        }
-                                      },
-                                      child: const Icon(
-                                        Icons.forward_10,
-                                        color: Colors.white,
-                                        size: 22,
-                                      ),
-                                    ),
-                                  ],
-                                ),
+                      opacity: _closeCtr.drive(Tween(begin: 1.0, end: 0.0)),
+                      child: ScaleTransition(
+                        scale: _closeCtr.drive(
+                          Tween(
+                            begin: 1.0,
+                            end: 0.85,
+                          ).chain(CurveTween(curve: Curves.easeOut)),
+                        ),
+                        child: AnimatedContainer(
+                          // 过渡中矩形逐帧由协调器插值给出;捏合/滚轮中尺寸须与
+                          // 位置同帧生效(见 _instantResize)。两者时长归零,
+                          // 仅双击档位切换保留 250ms 尺寸过渡
+                          duration: inTransition || _instantResize
+                              ? Duration.zero
+                              : const Duration(milliseconds: 250),
+                          curve: Curves.easeOutCubic,
+                          width: rect.width,
+                          height: rect.height,
+                          decoration: BoxDecoration(
+                            color: Colors.black,
+                            borderRadius: BorderRadius.circular(radius),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.5),
+                                blurRadius: 10,
+                                spreadRadius: 2,
                               ),
                             ],
-                          ],
+                          ),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(radius),
+                            child: Stack(
+                              children: [
+                                Positioned.fill(
+                                  child: AbsorbPointer(
+                                    child: widget.videoPlayerBuilder(
+                                      false,
+                                      rect.width,
+                                      rect.height,
+                                    ),
+                                  ),
+                                ),
+                                if (interactive && _showControls) ...[
+                                  Positioned.fill(
+                                    child: Container(
+                                      color: Colors.black.withValues(
+                                        alpha: 0.4,
+                                      ),
+                                    ),
+                                  ),
+                                  // 左上角关闭：先播缩小淡出再 stopPip
+                                  Positioned(
+                                    top: 3,
+                                    left: 4,
+                                    child: GestureDetector(
+                                      onTap: _beginClose,
+                                      child: const Padding(
+                                        padding: EdgeInsets.all(8.0),
+                                        child: Icon(
+                                          Icons.close,
+                                          color: Colors.white,
+                                          size: 21,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  // 右上角还原：归位动画启动，窗口保持显示飞向页面
+                                  Positioned(
+                                    top: 3,
+                                    right: 4,
+                                    child: GestureDetector(
+                                      onTap: () {
+                                        _hideTimer?.cancel();
+                                        widget.onTapToReturn();
+                                      },
+                                      child: const Padding(
+                                        padding: EdgeInsets.all(8.0),
+                                        child: Icon(
+                                          Icons.open_in_full,
+                                          color: Colors.white,
+                                          size: 19,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  // 底部控制栏
+                                  Positioned(
+                                    left: 0,
+                                    right: 0,
+                                    bottom: 8,
+                                    child: Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceEvenly,
+                                      children: [
+                                        // 后退10秒
+                                        GestureDetector(
+                                          onTap: () {
+                                            _resetHideTimer();
+                                            final controller =
+                                                PipOverlayService.getSavedController<
+                                                  VideoDetailController
+                                                >();
+                                            final plController =
+                                                controller?.plPlayerController;
+                                            if (plController != null) {
+                                              final current = Duration(
+                                                seconds:
+                                                    plController.position.value,
+                                              );
+                                              plController.seekTo(
+                                                current -
+                                                    const Duration(seconds: 10),
+                                              );
+                                            }
+                                          },
+                                          child: const Icon(
+                                            Icons.replay_10,
+                                            color: Colors.white,
+                                            size: 22,
+                                          ),
+                                        ),
+                                        // 播放/暂停
+                                        Obx(() {
+                                          final controller =
+                                              PipOverlayService.getSavedController<
+                                                VideoDetailController
+                                              >();
+                                          final plController =
+                                              controller?.plPlayerController;
+                                          final isPlaying =
+                                              plController
+                                                  ?.playerStatus
+                                                  .value ==
+                                              PlayerStatus.playing;
+                                          return GestureDetector(
+                                            onTap: () {
+                                              _resetHideTimer();
+                                              if (isPlaying) {
+                                                plController?.pause();
+                                              } else {
+                                                plController?.play();
+                                              }
+                                            },
+                                            child: Icon(
+                                              isPlaying
+                                                  ? Icons.pause
+                                                  : Icons.play_arrow,
+                                              color: Colors.white,
+                                              size: 30,
+                                            ),
+                                          );
+                                        }),
+                                        // 前进10秒
+                                        GestureDetector(
+                                          onTap: () {
+                                            _resetHideTimer();
+                                            final controller =
+                                                PipOverlayService.getSavedController<
+                                                  VideoDetailController
+                                                >();
+                                            final plController =
+                                                controller?.plPlayerController;
+                                            if (plController != null) {
+                                              final current = Duration(
+                                                seconds:
+                                                    plController.position.value,
+                                              );
+                                              plController.seekTo(
+                                                current +
+                                                    const Duration(seconds: 10),
+                                              );
+                                            }
+                                          },
+                                          child: const Icon(
+                                            Icons.forward_10,
+                                            color: Colors.white,
+                                            size: 22,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
-                ),
-              ),
               ),
             ),
           );


### PR DESCRIPTION
修复小窗缩放和位移不同步的动画问题

之前小窗在双击缩放时，位置和尺寸走的是两条不同的路径，位置瞬间变化而尺寸用动画过渡，导致小窗在屏幕边缘缩放时会出现抽搐和跳跃。现在把外层定位组件改成动画定位组件，和尺寸动画使用相同的时长和曲线，让位置和尺寸同步过渡，缩放动画变得顺滑。

修复双击缩放后窗口偏移的问题

小窗停在屏幕边缘时双击缩放，窗口会莫名其妙地跑到其他位置，贴右边放大再缩小时甚至会跑到左边。现在缩放前会先判断小窗离屏幕哪条边更近，就以那条边作为锚点，缩放后保持这条边到屏幕边缘的距离不变，窗口始终贴着自己原来的那侧缩放。
