### PR TITLE
chore(docs): 补充 AUR 安装方式并修正 repology 徽章指向

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Fork特性：
 - [x] Windows
 - [x] Linux
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/piliplus.svg)](https://repology.org/project/piliplus/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pilinara.svg)](https://repology.org/project/pilinara/versions)
 
 ## refactor
 
@@ -282,6 +282,23 @@ Fork特性：
 ## 下载
 
 可以通过右侧release进行下载或拉取代码到本地进行编译
+
+### Arch Linux (AUR)
+
+Arch Linux 用户可通过 AUR 安装：
+
+- `pilinara`（源码构建）
+- `pilinara-bin`（官方 Release 二进制）
+
+```bash
+# 使用 paru 安装二进制版
+paru -S pilinara-bin
+```
+
+```bash
+# 使用 yay 安装二进制版
+yay -S pilinara-bin
+```
 
 <br/>
 


### PR DESCRIPTION
您好！

我是 [pilinara](https://aur.archlinux.org/packages/pilinara) / [pilinara-bin](https://aur.archlinux.org/packages/pilinara-bin) 的 AUR 维护者，这次想为 README 补充 Arch Linux 的 AUR 安装方式，方便 Arch 用户群，另外顺手修正了 repology 打包状态徽章的指向

顺便反馈两个影响 AUR 自动化维护的问题：

1. main 分支与活跃开发分支同步比较慢，而开发分支本身一直在变，版本和依赖经常滞后，源码包构建时需要额外处理，这也让我放弃了维护 `-git` 包的计划
2. 正式版本 tag 不符合版本号规范，例如 `2.1.0.1-Himeko`、`2.0.7.4-Hyacinthia` 带英文代号后缀。按 Arch 的 [vercmp](https://man.archlinux.org/man/vercmp.8) 规则，这类 tag 无法正确解析排序，AUR 无法自动跟踪版本更新，只能手动维护

建议 tag 使用纯粹的数字版本号（如 `2.1.0.2`），预发布版本用 `-1`/`-2` 之类的后缀（如 `2.1.0.2-1`），这样下游打包工具才能自动化处理。像现在的 `2.1.0.2-betaX` 就符合这个规范

如果这两个问题能改善，对下游打包和用户安装都会方便很多。感谢您的优秀作品和辛苦维护！

nlsdt
2026-08-12