### PR TITLE
fix(debian): correct Homepage URL in DEBIAN/control

### DIFF
--- a/assets/linux/DEBIAN/control
+++ b/assets/linux/DEBIAN/control
@@ -8,7 +8,7 @@ Architecture: amd64
 Essential: no
 Installed-Size: size_need_change
 Description: third-party Bilibili client developed in Flutter
-Homepage: https://github.com/bggRGjQaUbCoE/PiliNara
+Homepage: https://github.com/Starfallan/PiliNara
 Depends: libgtk-3-0t64,
          libmpv2,
          gir1.2-ayatanaappindicator3-0.1,


### PR DESCRIPTION
原 Homepage 指向 `bggRGjQaUbCoE/PiliNara`，该地址不存在（返回 404）。
已更新为实际仓库 `Starfallan/PiliNara`。