### PR TITLE
fix(linux): disable Impeller by default for stability

### DIFF
--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -76,7 +76,7 @@ static void my_application_activate(GApplication *application) {
   gtk_window_set_default_size(window, 1280, 720);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
-  fl_dart_project_set_enable_impeller(project, FALSE); //disabled linux impeller rendering
+  fl_dart_project_set_enable_impeller(project, FALSE); // Disable Impeller on Linux due to current stability issues.
 
   fl_dart_project_set_dart_entrypoint_arguments(
       project, self->dart_entrypoint_arguments);

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -76,6 +76,8 @@ static void my_application_activate(GApplication *application) {
   gtk_window_set_default_size(window, 1280, 720);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_enable_impeller(project, FALSE); //disabled linux impeller rendering
+
   fl_dart_project_set_dart_entrypoint_arguments(
       project, self->dart_entrypoint_arguments);
 


### PR DESCRIPTION
## 说明

### 问题

项目升级到 Flutter 3.47.0 后，Impeller 开始在 Linux 平台默认启用。

在实际使用中遇到了 Linux 端崩溃，systemd coredump 显示：

* 进程收到 `SIGSEGV`
* 崩溃线程为 Flutter raster 线程 `io.flutter.rast`
* 调用栈主要位于 `libflutter_linux_gtk.so`

同时目前开启 Impeller 后，Linux 端的动画流畅度也没有观察到明显改善。

### 修改

在 Linux runner 创建 `FlDartProject` 后显式关闭 Impeller：

```cpp
g_autoptr(FlDartProject) project = fl_dart_project_new();
fl_dart_project_set_enable_impeller(project, FALSE);
```

仅影响 Linux 平台，不改变 Android、Windows、macOS 等其他平台的渲染配置。

### 原因

Flutter 3.47 的 Linux Impeller 支持目前可能仍存在部分兼容性问题。

PiliNara 包含视频播放等较复杂的渲染场景，在 Linux 上默认启用 Impeller 后出现 raster thread 原生崩溃。相比默认启用一个可能导致整个应用直接退出的新渲染路径，暂时继续使用原有渲染后端会更稳妥。

后续如果 Flutter 上游修复相关问题并且 Linux Impeller 稳定性得到验证，可以再重新启用。
