### PR TITLE
feat: 动态列表支持长按评论按钮快速回复

### DIFF
--- a/assets/linux/DEBIAN/control
+++ b/assets/linux/DEBIAN/control
@@ -8,7 +8,7 @@ Architecture: amd64
 Essential: no
 Installed-Size: size_need_change
 Description: third-party Bilibili client developed in Flutter
-Homepage: https://github.com/bggRGjQaUbCoE/PiliNara
+Homepage: https://github.com/Starfallan/PiliNara
 Depends: libgtk-3-0t64,
          libmpv2,
          gir1.2-ayatanaappindicator3-0.1,

--- a/lib/pages/dynamics/widgets/action_panel.dart
+++ b/lib/pages/dynamics/widgets/action_panel.dart
@@ -1,10 +1,20 @@
+import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
+    show ReplyInfo;
+import 'package:PiliPlus/http/dynamics.dart';
+import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/dynamics/result.dart';
+import 'package:PiliPlus/pages/common/publish/publish_route.dart';
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
+import 'package:PiliPlus/pages/video/reply_new/view.dart';
+import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:PiliPlus/utils/num_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/request_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:get/get.dart';
 
 class ActionPanel extends StatelessWidget {
   const ActionPanel({
@@ -12,6 +22,67 @@ class ActionPanel extends StatelessWidget {
     required this.item,
   });
   final DynamicItemModel item;
+
+  void _onQuickReply(VoidCallback onUpdateUi) {
+    feedBack();
+    final commentType = item.basic?.commentType;
+    final commentIdStr = item.basic?.commentIdStr;
+    if (commentType != null &&
+        commentType != 0 &&
+        commentIdStr != null &&
+        commentIdStr.isNotEmpty) {
+      _showReplyPage(int.parse(commentIdStr), commentType, onUpdateUi);
+    } else {
+      SmartDialog.showLoading(msg: '加载中...');
+      DynamicsHttp.dynamicDetail(id: item.idStr)
+          .then((res) {
+            SmartDialog.dismiss(status: SmartStatus.loading);
+            if (res case Success(:final response)) {
+              final bCommentId = response.basic?.commentIdStr;
+              final bCommentType = response.basic?.commentType;
+              if (bCommentId != null &&
+                  bCommentId.isNotEmpty &&
+                  bCommentType != null &&
+                  bCommentType != 0) {
+                _showReplyPage(int.parse(bCommentId), bCommentType, onUpdateUi);
+              } else {
+                SmartDialog.showToast('该动态不支持快速评论');
+              }
+            } else {
+              res.toast();
+            }
+          })
+          .catchError((e) {
+            SmartDialog.dismiss(status: SmartStatus.loading);
+            SmartDialog.showToast(e.toString());
+          });
+    }
+  }
+
+  void _showReplyPage(int oid, int replyType, VoidCallback onUpdateUi) {
+    Get.key.currentState!
+        .push(
+          PublishRoute(
+            pageBuilder: (buildContext, animation, secondaryAnimation) {
+              return ReplyPage(
+                oid: oid,
+                root: 0,
+                parent: 0,
+                replyType: replyType,
+              );
+            },
+          ),
+        )
+        .then((replyInfo) {
+          if (replyInfo is ReplyInfo) {
+            final comment = item.modules.moduleStat?.comment;
+            if (comment != null) {
+              comment.count = (comment.count ?? 0) + 1;
+              onUpdateUi();
+            }
+          }
+        });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,22 +137,35 @@ class ActionPanel extends StatelessWidget {
           ),
         ),
         Expanded(
-          child: TextButton.icon(
-            onPressed: () => PageUtils.pushDynDetail(
-              item,
-              isPush: true,
-              viewComment: true,
-            ),
-            icon: Icon(
-              FontAwesomeIcons.comment,
-              size: 16,
-              color: outline,
-              semanticLabel: "评论",
-            ),
-            style: btnStyle,
-            label: Text(
-              comment.count != null ? NumUtils.numFormat(comment.count) : '评论',
-            ),
+          child: Builder(
+            builder: (context) {
+              return TextButton.icon(
+                onPressed: () => PageUtils.pushDynDetail(
+                  item,
+                  isPush: true,
+                  viewComment: true,
+                ),
+                onLongPress: Pref.enableQuickReplyDyn
+                    ? () => _onQuickReply(() {
+                        if (context.mounted) {
+                          (context as Element?)?.markNeedsBuild();
+                        }
+                      })
+                    : null,
+                icon: Icon(
+                  FontAwesomeIcons.comment,
+                  size: 16,
+                  color: outline,
+                  semanticLabel: "评论",
+                ),
+                style: btnStyle,
+                label: Text(
+                  comment.count != null
+                      ? NumUtils.numFormat(comment.count)
+                      : '评论',
+                ),
+              );
+            },
           ),
         ),
         Expanded(

--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -601,6 +601,13 @@ List<SettingsModel> get extraSettings => [
     defaultVal: true,
     onChanged: (val) => ItemModulesModel.showDynInteraction = val,
   ),
+  const SwitchModel(
+    title: '动态长按快捷评论',
+    subtitle: '在动态列表长按评论按钮快速弹出评论输入框',
+    leading: Icon(Icons.comment_outlined),
+    setKey: SettingBoxKey.enableQuickReplyDyn,
+    defaultVal: true,
+  ),
   NormalModel(
     title: '用户页默认展示TAB',
     leading: const Icon(Icons.tab),

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -73,6 +73,7 @@ abstract final class SettingBoxKey {
       replySortType = 'replySortType',
       defaultDynamicType = 'defaultDynamicType',
       showDynInteraction = 'showDynInteraction',
+      enableQuickReplyDyn = 'enableQuickReplyDyn',
       enableHotKey = 'enableHotKey',
       enableSearchRcmd = 'enableSearchRcmd',
       enableQuickFav = 'enableQuickFav',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -557,6 +557,9 @@ abstract final class Pref {
   static bool get showDynInteraction =>
       _setting.get(SettingBoxKey.showDynInteraction, defaultValue: true);
 
+  static bool get enableQuickReplyDyn =>
+      _setting.get(SettingBoxKey.enableQuickReplyDyn, defaultValue: true);
+
   static double get blockLimit =>
       _setting.get(SettingBoxKey.blockLimit, defaultValue: 0.0);
 


### PR DESCRIPTION
## 描述
新增「长按快捷评论」开关。开启后，用户可长按动态列表中的评论按钮，直接弹出输入框发送评论，不必进入动态详情页。

## 改动说明
1. **动态卡片交互**：在动态流卡片底部操作栏中，长按“评论”按钮触发快速回复浮层。若动态数据中未携带评论区信息，会自动请求接口获取对应 commentId/commentType 后弹出。
2. **即时刷新**：发表评论成功后，动态卡片的评论计数会即时 +1。
3. **设置项**：在「其他设置」中新增「动态长按快捷评论」开关（默认开启），可按需关闭。
4. **兼容性**：原有单击跳转动态详情页逻辑保持完全不变。

## [测试构建](https://github.com/qpst4/PiliPlus/actions/runs/32464076476)

- Android 与 Windows 实机测试通过
- 动态长按快评、评论数即时刷新与设置开关测试通过
- 全平台构建通过
